### PR TITLE
Create a specific launcher class in a "maven module" not using "java modules"

### DIFF
--- a/nmrfx-launchers/pom.xml
+++ b/nmrfx-launchers/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.nmrfx</groupId>
+        <artifactId>nmrfx</artifactId>
+        <version>11.1.39</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>nmrfx-launchers</artifactId>
+    <version>11.1.39</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.nmrfx</groupId>
+            <artifactId>nmrfx-analyst-gui</artifactId>
+            <version>11.1.39</version>
+        </dependency>
+	</dependencies>
+
+</project>

--- a/nmrfx-launchers/src/main/java/org/nmrfx/launchers/RunAnalystWithoutModules.java
+++ b/nmrfx-launchers/src/main/java/org/nmrfx/launchers/RunAnalystWithoutModules.java
@@ -1,0 +1,10 @@
+package org.nmrfx.launchers;
+
+import javafx.application.Application;
+import org.nmrfx.analyst.gui.AnalystApp;
+
+public class RunAnalystWithoutModules {
+    public static void main(String[] args) {
+        Application.launch(AnalystApp.class, args);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <module>nmrfx-structure</module>
         <module>nmrfx-analyst</module>
         <module>nmrfx-analyst-gui</module>
+        <module>nmrfx-launchers</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
Create a specific launcher class in a "maven module" not using "java modules", to run using the classpath way.

This is similar to what the .bat and .sh do.