### PR TITLE
NMR-4493 Import jcamp-parser as dependency.

### DIFF
--- a/nmrfx-bom/pom.xml
+++ b/nmrfx-bom/pom.xml
@@ -22,7 +22,7 @@
             <dependency>
                 <groupId>com.nanalysis</groupId>
                 <artifactId>jcamp-parser</artifactId>
-                <version>1.0</version>
+                <version>1.0.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/nmrfx-bom/pom.xml
+++ b/nmrfx-bom/pom.xml
@@ -20,6 +20,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.nanalysis</groupId>
+                <artifactId>jcamp-parser</artifactId>
+                <version>1.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-math3</artifactId>
                 <version>3.6</version>

--- a/nmrfx-processor/pom.xml
+++ b/nmrfx-processor/pom.xml
@@ -32,6 +32,10 @@
             <version>${revision}</version>
         </dependency>
         <dependency>
+            <groupId>com.nanalysis</groupId>
+            <artifactId>jcamp-parser</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.jnr</groupId>
             <artifactId>jnr-posix</artifactId>
         </dependency>

--- a/nmrfx-processor/src/main/java/module-info.java
+++ b/nmrfx-processor/src/main/java/module-info.java
@@ -26,4 +26,5 @@ module org.nmrfx.processor {
     requires janino;
     requires commons.compiler;
     requires jython.slim;
+    requires com.nanalysis.jcamp;
 }


### PR DESCRIPTION
Separated the dependency import as it's own PR to isolate the import in case it causes errors. This needs to wait for the spelling error to be fixed in the jcamp-parser module-info.java file to be accurate.