### PR TITLE
NMR-4491: force format locale to avoid comma in formatted numbers

### DIFF
--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/AnalystApp.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/AnalystApp.java
@@ -59,6 +59,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Calendar;
+import java.util.Locale;
 import java.util.Optional;
 
 public class AnalystApp extends MainApp {
@@ -112,6 +113,9 @@ public class AnalystApp extends MainApp {
     @Override
     public void start(Stage stage) throws Exception {
         Log.setupMemoryAppender();
+
+        //necessary to avoid "," as a decimal separator in output files or python scripts
+        Locale.setDefault(Locale.Category.FORMAT, Locale.US);
 
         if (isMac()) {
             System.setProperty("prism.lcdtext", "false");

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/MainApp.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/MainApp.java
@@ -53,6 +53,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -136,12 +137,12 @@ public class MainApp extends Application {
         defaultFont = Font.loadFont(iStream, 12);
     }
 
-//    public static void addPeakListListener(MapChangeListener<String, PeakList> mapChangeListener) {
-//        ((ObservableMap<String, PeakList>) PeakList.peakListTable).addListener(mapChangeListener);
-//    }
     @Override
     public void start(Stage stage) throws Exception {
         Log.setupMemoryAppender();
+
+        //necessary to avoid "," as a decimal separator in output files or python scripts
+        Locale.setDefault(Locale.Category.FORMAT, Locale.US);
 
         mainApp = this;
         FXMLController controller = FXMLController.create(stage);


### PR DESCRIPTION
The alternative would be to specify the formatting locale when calling `String.format(..)`, at least in `Phaser`.
That would be cleaner, especially if we expect to translate the software one day, but the risk of forgetting that in future calls is huge. 
This is also called when creating STAR3 files (peak lists) among others, which I suspect wouldn't work with commas in numbers either.