### PR TITLE
Nmr 5145 duplicated options in tool menu

### DIFF
--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/AnalystApp.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/AnalystApp.java
@@ -348,13 +348,13 @@ public class AnalystApp extends MainApp {
         if (viewMenuActions != null) {
             viewMenuActions.activateAdvanced();
         }
-        addAdvancedtools();
-        advancedIsActive = true;
+        if (!advancedIsActive) {
+            addAdvancedTools();
+            advancedIsActive = true;
+        }
         if (startAdvancedItem != null) {
             startAdvancedItem.setDisable(true);
         }
-
-
     }
 
     public void readMolecule(String type) {
@@ -397,7 +397,7 @@ public class AnalystApp extends MainApp {
         }
     }
 
-    private void addAdvancedtools() {
+    private void addAdvancedTools() {
         for (var controller: FXMLController.getControllers()) {
             addAdvancedTools(controller.getStatusBar());
         }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/spectra/SpectrumMenuActions.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/spectra/SpectrumMenuActions.java
@@ -5,6 +5,7 @@ import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
+import javafx.stage.StageStyle;
 import org.nmrfx.analyst.gui.AnalystApp;
 import org.nmrfx.analyst.gui.MenuActions;
 import org.nmrfx.processor.gui.FXMLController;
@@ -98,7 +99,9 @@ public class SpectrumMenuActions extends MenuActions {
     }
 
     private void newGraphics(ActionEvent event) {
-        FXMLController.create();
+        Stage stage = new Stage(StageStyle.DECORATED);
+        stage.setTitle(AnalystApp.getAppName() + " " + AnalystApp.getVersion());
+        FXMLController.create(stage);
     }
 
     public void showStripsBar() {

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -1403,7 +1403,6 @@ public class FXMLController implements  Initializable, PeakNavigable {
             FXMLController myController = controller;
             stage.focusedProperty().addListener(e -> myController.setActiveController(e));
             controller.setActiveController();
-            stage.setTitle("NMRFx Processor");
             MainApp.registerStage(stage, controller);
             stage.show();
         } catch (IOException ioE) {


### PR DESCRIPTION
The menu options were being added twice on the first window and added again to each window each time a new window was opened. If 4 windows were open:
window 1 - options * 5
window 2 - options * 3
window 3 - options * 2
window 1 - options * 1

Also replaced hardcoded old window title.