### PR TITLE
specify classifiers for platform-specific dependencies

### DIFF
--- a/nmrfx-bom/pom.xml
+++ b/nmrfx-bom/pom.xml
@@ -15,6 +15,10 @@
     <properties>
         <nd4j.version>1.0.0-beta7</nd4j.version>
         <dl4j.version>1.0.0-beta7</dl4j.version>
+        <openblas.version>0.3.20-1.5.8-SNAPSHOT</openblas.version>
+        <arpack.version>3.8.0-1.5.7</arpack.version>
+        <javacpp.version>1.5.8-SNAPSHOT</javacpp.version>
+        <mkl.version>2020.1-1.5.3</mkl.version>
     </properties>
 
     <dependencyManagement>
@@ -112,7 +116,71 @@
             <dependency>
                 <groupId>org.nd4j</groupId>
                 <artifactId>nd4j-native-platform</artifactId>
-                <version>${dl4j.version}</version>
+                <version>${nd4j.version}</version>
+                <!-- license: Apache License, Version 2.0 -->
+                <exclusions>
+                    <!-- excluding nd4j-native because it includes all platforms -->
+                    <!-- only the necessary ones should be included -->
+                    <exclusion>
+                        <groupId>org.nd4j</groupId>
+                        <artifactId>nd4j-native</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.nd4j</groupId>
+                <artifactId>nd4j-native</artifactId>
+                <version>${nd4j.version}</version>
+                <classifier>linux-x86_64</classifier>
+                <!-- license: Apache License, Version 2.0 -->
+            </dependency>
+            <dependency>
+                <groupId>org.nd4j</groupId>
+                <artifactId>nd4j-native</artifactId>
+                <version>${nd4j.version}</version>
+                <classifier>macosx-x86_64</classifier>
+                <!-- license: Apache License, Version 2.0 -->
+            </dependency>
+            <dependency>
+                <groupId>org.nd4j</groupId>
+                <artifactId>nd4j-native</artifactId>
+                <version>${nd4j.version}</version>
+                <classifier>windows-x86_64</classifier>
+                <!-- license: Apache License, Version 2.0 -->
+            </dependency>
+            <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>mkl-platform</artifactId>
+                <version>${mkl.version}</version>
+                <!-- license: Apache License, Version 2.0 -->
+                <exclusions>
+                    <!-- excluding mkl because it includes all platforms -->
+                    <!-- only the necessary ones should be included -->
+                    <exclusion>
+                        <groupId>org.bytedeco</groupId>
+                        <artifactId>mkl</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>mkl</artifactId>
+                <version>${mkl.version}</version>
+                <classifier>linux-x86_64</classifier>
+                <!-- license: Apache License, Version 2.0 -->
+            </dependency>
+            <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>mkl</artifactId>
+                <version>${mkl.version}</version>
+                <classifier>macosx-x86_64</classifier>
+                <!-- license: Apache License, Version 2.0 -->
+            </dependency>
+            <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>mkl</artifactId>
+                <version>${mkl.version}</version>
+                <classifier>windows-x86_64</classifier>
                 <!-- license: Apache License, Version 2.0 -->
             </dependency>
             <dependency>
@@ -264,20 +332,121 @@
             </dependency>
             <dependency>
                 <groupId>org.bytedeco</groupId>
+                <artifactId>javacpp-platform</artifactId>
+                <version>${javacpp.version}</version>
+                <!-- license: Apache 2 / GPLv2 with ClassPath exception -->
+                <exclusions>
+                    <!-- excluding openblas because it includes all platforms -->
+                    <!-- only the necessary ones should be included -->
+                    <exclusion>
+                        <groupId>org.bytedeco</groupId>
+                        <artifactId>javacpp</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.bytedeco</groupId>
                 <artifactId>javacpp</artifactId>
-                <version>1.5.7</version>
+                <version>${javacpp.version}</version>
+                <classifier>linux-x86_64</classifier>
+                <!-- license: Apache 2 / GPLv2 with ClassPath exception -->
+            </dependency>
+            <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>javacpp</artifactId>
+                <version>${javacpp.version}</version>
+                <classifier>macosx-arm64</classifier>
+                <!-- license: Apache 2 / GPLv2 with ClassPath exception -->
+            </dependency>
+            <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>javacpp</artifactId>
+                <version>${javacpp.version}</version>
+                <classifier>macosx-x86_64</classifier>
+                <!-- license: Apache 2 / GPLv2 with ClassPath exception -->
+            </dependency>
+            <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>javacpp</artifactId>
+                <version>${javacpp.version}</version>
+                <classifier>windows-x86_64</classifier>
                 <!-- license: Apache 2 / GPLv2 with ClassPath exception -->
             </dependency>
             <dependency>
                 <groupId>org.bytedeco</groupId>
                 <artifactId>openblas-platform</artifactId>
-                <version>0.3.20-1.5.8-SNAPSHOT</version>
+                <version>${openblas.version}</version>
+                <!-- license: Apache 2 / GPLv2 with ClassPath exception -->
+                <exclusions>
+                    <!-- excluding openblas because it includes all platforms -->
+                    <!-- only the necessary ones should be included -->
+                    <exclusion>
+                        <groupId>org.bytedeco</groupId>
+                        <artifactId>openblas</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>openblas</artifactId>
+                <version>${openblas.version}</version>
+                <classifier>linux-x86_64</classifier>
+                <!-- license: Apache 2 / GPLv2 with ClassPath exception -->
+            </dependency>
+            <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>openblas</artifactId>
+                <version>${openblas.version}</version>
+                <classifier>macosx-arm64</classifier>
+                <!-- license: Apache 2 / GPLv2 with ClassPath exception -->
+            </dependency>
+            <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>openblas</artifactId>
+                <version>${openblas.version}</version>
+                <classifier>macosx-x86_64</classifier>
+                <!-- license: Apache 2 / GPLv2 with ClassPath exception -->
+            </dependency>
+            <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>openblas</artifactId>
+                <version>${openblas.version}</version>
+                <classifier>windows-x86_64</classifier>
                 <!-- license: Apache 2 / GPLv2 with ClassPath exception -->
             </dependency>
             <dependency>
                 <groupId>org.bytedeco</groupId>
                 <artifactId>arpack-ng-platform</artifactId>
-                <version>3.8.0-1.5.7</version>
+                <version>${arpack.version}</version>
+                <!-- license: Apache 2 / GPLv2 with ClassPath exception -->
+                <exclusions>
+                    <!-- excluding arpack-ng because it includes all platforms -->
+                    <!-- only the necessary ones should be included -->
+                    <exclusion>
+                        <groupId>org.bytedeco</groupId>
+                        <artifactId>arpack-ng</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>arpack-ng</artifactId>
+                <version>${arpack.version}</version>
+                <classifier>linux-x86_64</classifier>
+                <!-- license: Apache 2 / GPLv2 with ClassPath exception -->
+            </dependency>
+            <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>arpack-ng</artifactId>
+                <version>${arpack.version}</version>
+                <classifier>macosx-x86_64</classifier>
+                <!-- license: Apache 2 / GPLv2 with ClassPath exception -->
+            </dependency>
+            <dependency>
+                <groupId>org.bytedeco</groupId>
+                <artifactId>arpack-ng</artifactId>
+                <version>${arpack.version}</version>
+                <classifier>windows-x86_64</classifier>
                 <!-- license: Apache 2 / GPLv2 with ClassPath exception -->
             </dependency>
             <dependency>

--- a/nmrfx-core/pom.xml
+++ b/nmrfx-core/pom.xml
@@ -80,6 +80,36 @@
             <artifactId>nd4j-native-platform</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.nd4j</groupId>
+            <artifactId>nd4j-native</artifactId>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.nd4j</groupId>
+            <artifactId>nd4j-native</artifactId>
+            <classifier>macosx-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.nd4j</groupId>
+            <artifactId>nd4j-native</artifactId>
+            <classifier>windows-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>mkl</artifactId>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>mkl</artifactId>
+            <classifier>macosx-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>mkl</artifactId>
+            <classifier>windows-x86_64</classifier>
+        </dependency>
+        <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>

--- a/nmrfx-processor/pom.xml
+++ b/nmrfx-processor/pom.xml
@@ -87,6 +87,22 @@
         <dependency>
             <groupId>org.bytedeco</groupId>
             <artifactId>javacpp</artifactId>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>javacpp</artifactId>
+            <classifier>macosx-arm64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>javacpp</artifactId>
+            <classifier>macosx-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>javacpp</artifactId>
+            <classifier>windows-x86_64</classifier>
         </dependency>
         <dependency>
             <groupId>org.bytedeco</groupId>
@@ -94,7 +110,42 @@
         </dependency>
         <dependency>
             <groupId>org.bytedeco</groupId>
+            <artifactId>openblas</artifactId>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>openblas</artifactId>
+            <classifier>macosx-arm64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>openblas</artifactId>
+            <classifier>macosx-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>openblas</artifactId>
+            <classifier>windows-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
             <artifactId>arpack-ng-platform</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>arpack-ng</artifactId>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>arpack-ng</artifactId>
+            <classifier>macosx-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>arpack-ng</artifactId>
+            <classifier>windows-x86_64</classifier>
         </dependency>
         <dependency>
             <groupId>org.python</groupId>

--- a/nmrfx-structure/pom.xml
+++ b/nmrfx-structure/pom.xml
@@ -84,6 +84,22 @@
         <dependency>
             <groupId>org.bytedeco</groupId>
             <artifactId>javacpp</artifactId>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>javacpp</artifactId>
+            <classifier>macosx-arm64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>javacpp</artifactId>
+            <classifier>macosx-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>javacpp</artifactId>
+            <classifier>windows-x86_64</classifier>
         </dependency>
         <dependency>
             <groupId>org.bytedeco</groupId>
@@ -91,7 +107,42 @@
         </dependency>
         <dependency>
             <groupId>org.bytedeco</groupId>
+            <artifactId>openblas</artifactId>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>openblas</artifactId>
+            <classifier>macosx-arm64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>openblas</artifactId>
+            <classifier>macosx-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>openblas</artifactId>
+            <classifier>windows-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
             <artifactId>arpack-ng-platform</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>arpack-ng</artifactId>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>arpack-ng</artifactId>
+            <classifier>macosx-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.bytedeco</groupId>
+            <artifactId>arpack-ng</artifactId>
+            <classifier>windows-x86_64</classifier>
         </dependency>
         <dependency>
             <groupId>org.deeplearning4j</groupId>


### PR DESCRIPTION
also fix javacpp/openblas version mismatch

This should generate smaller assembly and maybe build a little faster. 
The main goal is to remove the need for `cleanlibs` script before generating installers.

I would have liked to be able to only exclude certain classifiers, but maven doesn't seem to have this feature, so we have to exclude the main dependency and include manually the specific platforms we need.


**Edit after build**: the analyst zip assembly weighs 250Mb less!