### PR TITLE
NMR-5222: add permissions to test data submodule to cleanup.yml

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v2
         with:
+          token: ${{ secrets.SUBMODULE_ACCESS_TOKEN }}
+          lfs: 'true'
           # Check-out the submodules as well
           submodules: 'recursive'
 


### PR DESCRIPTION
Cleanup.yml failed on branch delete, as it couldn't find the test-data repository, made the checkout command use the same format as build.yml

![image](https://user-images.githubusercontent.com/64663455/176481850-dd45a21d-cdce-4ef8-bff4-37765857607b.png)
