### PR TITLE
NMR-5223: exclude unsupported native platforms in assemblies

### DIFF
--- a/nmrfx-analyst-gui/src/main/assembly/component.xml
+++ b/nmrfx-analyst-gui/src/main/assembly/component.xml
@@ -53,6 +53,21 @@
         <dependencySet>
             <outputDirectory>lib</outputDirectory>
             <excludes>
+                <!--
+                Exclude native libraries for unsupported platforms.
+                The only platforms we want to keep are: linux-x86_64, macosx_arm64, macosx_x86_64, windows-x86_64.
+                -->
+                <exclude>*:android-arm</exclude>
+                <exclude>*:android-arm64</exclude>
+                <exclude>*:android-x86</exclude>
+                <exclude>*:android-x86_64</exclude>
+                <exclude>*:ios-arm64</exclude>
+                <exclude>*:ios-x86_64</exclude>
+                <exclude>*:linux-arm64</exclude>
+                <exclude>*:linux-armhf</exclude>
+                <exclude>*:linux-ppc64le</exclude>
+                <exclude>*:linux-x86</exclude>
+                <exclude>*:windows-x86</exclude>
             </excludes>
             <unpack>false</unpack>
         </dependencySet>

--- a/nmrfx-analyst/src/main/assembly/component.xml
+++ b/nmrfx-analyst/src/main/assembly/component.xml
@@ -55,6 +55,21 @@
         <dependencySet>
             <outputDirectory>lib</outputDirectory>
             <excludes>
+                <!--
+                Exclude native libraries for unsupported platforms.
+                The only platforms we want to keep are: linux-x86_64, macosx_arm64, macosx_x86_64, windows-x86_64.
+                -->
+                <exclude>*:android-arm</exclude>
+                <exclude>*:android-arm64</exclude>
+                <exclude>*:android-x86</exclude>
+                <exclude>*:android-x86_64</exclude>
+                <exclude>*:ios-arm64</exclude>
+                <exclude>*:ios-x86_64</exclude>
+                <exclude>*:linux-arm64</exclude>
+                <exclude>*:linux-armhf</exclude>
+                <exclude>*:linux-ppc64le</exclude>
+                <exclude>*:linux-x86</exclude>
+                <exclude>*:windows-x86</exclude>
             </excludes>
             <unpack>false</unpack>
         </dependencySet>

--- a/nmrfx-core/src/main/assembly/component.xml
+++ b/nmrfx-core/src/main/assembly/component.xml
@@ -55,6 +55,21 @@
         <dependencySet>
             <outputDirectory>lib</outputDirectory>
             <excludes>
+                <!--
+                Exclude native libraries for unsupported platforms.
+                The only platforms we want to keep are: linux-x86_64, macosx_arm64, macosx_x86_64, windows-x86_64.
+                -->
+                <exclude>*:android-arm</exclude>
+                <exclude>*:android-arm64</exclude>
+                <exclude>*:android-x86</exclude>
+                <exclude>*:android-x86_64</exclude>
+                <exclude>*:ios-arm64</exclude>
+                <exclude>*:ios-x86_64</exclude>
+                <exclude>*:linux-arm64</exclude>
+                <exclude>*:linux-armhf</exclude>
+                <exclude>*:linux-ppc64le</exclude>
+                <exclude>*:linux-x86</exclude>
+                <exclude>*:windows-x86</exclude>
             </excludes>
             <unpack>false</unpack>
         </dependencySet>

--- a/nmrfx-processor-gui/src/main/assembly/component.xml
+++ b/nmrfx-processor-gui/src/main/assembly/component.xml
@@ -54,6 +54,21 @@
         <dependencySet>
             <outputDirectory>lib</outputDirectory>
             <excludes>
+                <!--
+                Exclude native libraries for unsupported platforms.
+                The only platforms we want to keep are: linux-x86_64, macosx_arm64, macosx_x86_64, windows-x86_64.
+                -->
+                <exclude>*:android-arm</exclude>
+                <exclude>*:android-arm64</exclude>
+                <exclude>*:android-x86</exclude>
+                <exclude>*:android-x86_64</exclude>
+                <exclude>*:ios-arm64</exclude>
+                <exclude>*:ios-x86_64</exclude>
+                <exclude>*:linux-arm64</exclude>
+                <exclude>*:linux-armhf</exclude>
+                <exclude>*:linux-ppc64le</exclude>
+                <exclude>*:linux-x86</exclude>
+                <exclude>*:windows-x86</exclude>
             </excludes>
             <unpack>false</unpack>
         </dependencySet>

--- a/nmrfx-processor/src/main/assembly/component.xml
+++ b/nmrfx-processor/src/main/assembly/component.xml
@@ -55,6 +55,21 @@
         <dependencySet>
             <outputDirectory>lib</outputDirectory>
             <excludes>
+                <!--
+                Exclude native libraries for unsupported platforms.
+                The only platforms we want to keep are: linux-x86_64, macosx_arm64, macosx_x86_64, windows-x86_64.
+                -->
+                <exclude>*:android-arm</exclude>
+                <exclude>*:android-arm64</exclude>
+                <exclude>*:android-x86</exclude>
+                <exclude>*:android-x86_64</exclude>
+                <exclude>*:ios-arm64</exclude>
+                <exclude>*:ios-x86_64</exclude>
+                <exclude>*:linux-arm64</exclude>
+                <exclude>*:linux-armhf</exclude>
+                <exclude>*:linux-ppc64le</exclude>
+                <exclude>*:linux-x86</exclude>
+                <exclude>*:windows-x86</exclude>
             </excludes>
             <unpack>false</unpack>
         </dependencySet>

--- a/nmrfx-structure/src/main/assembly/component.xml
+++ b/nmrfx-structure/src/main/assembly/component.xml
@@ -55,6 +55,21 @@
         <dependencySet>
             <outputDirectory>lib</outputDirectory>
             <excludes>
+                <!--
+                Exclude native libraries for unsupported platforms.
+                The only platforms we want to keep are: linux-x86_64, macosx_arm64, macosx_x86_64, windows-x86_64.
+                -->
+                <exclude>*:android-arm</exclude>
+                <exclude>*:android-arm64</exclude>
+                <exclude>*:android-x86</exclude>
+                <exclude>*:android-x86_64</exclude>
+                <exclude>*:ios-arm64</exclude>
+                <exclude>*:ios-x86_64</exclude>
+                <exclude>*:linux-arm64</exclude>
+                <exclude>*:linux-armhf</exclude>
+                <exclude>*:linux-ppc64le</exclude>
+                <exclude>*:linux-x86</exclude>
+                <exclude>*:windows-x86</exclude>
             </excludes>
             <unpack>false</unpack>
         </dependencySet>


### PR DESCRIPTION
Alternative to https://github.com/nanalysis/nmrfx/pull/132.
Don't exclude dependencies in the build, only in assembly.

Luckily, maven-assembly-plugin allows excluding based on classifiers.