### PR TITLE
Nmr 5326 test 2 d jcamp files from spinit

### DIFF
--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/jcamp/JCAMPData.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/jcamp/JCAMPData.java
@@ -759,10 +759,14 @@ public class JCAMPData implements NMRData {
         if("sep".equals(getSymbolicCoefs(dim))) {
             return false;
         }
-
-        return block.optional($REVERSE, dim).map(JCampRecord::getString)
+        boolean negateImage = block.optional($REVERSE, dim).map(JCampRecord::getString)
                 .map("yes"::equalsIgnoreCase)
                 .orElse(true);
+        AcquisitionScheme scheme = getAcquisitionScheme();
+        if (scheme == AcquisitionScheme.ECHO_ANTIECHO || scheme == AcquisitionScheme.STATES_TPPI) {
+            negateImage = !negateImage;
+        }
+        return negateImage;
     }
 
     @Override

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/jcamp/JCAMPData.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/jcamp/JCAMPData.java
@@ -318,7 +318,7 @@ public class JCAMPData implements NMRData {
     }
 
     private Optional<Label> getSFLabel(int dim) {
-        return Stream.of(_OBSERVE_FREQUENCY, $SFO1)
+        return Stream.of($SFO1, _OBSERVE_FREQUENCY)
                 .filter(label -> block.optional(label, dim).isPresent())
                 .findFirst();
     }
@@ -759,14 +759,12 @@ public class JCAMPData implements NMRData {
         if("sep".equals(getSymbolicCoefs(dim))) {
             return false;
         }
-        boolean negateImage = block.optional($REVERSE, dim).map(JCampRecord::getString)
+        boolean reverse = block.optional($REVERSE, dim).map(JCampRecord::getString)
                 .map("yes"::equalsIgnoreCase)
                 .orElse(true);
         AcquisitionScheme scheme = getAcquisitionScheme();
-        if (scheme == AcquisitionScheme.ECHO_ANTIECHO || scheme == AcquisitionScheme.STATES_TPPI) {
-            negateImage = !negateImage;
-        }
-        return negateImage;
+        // For certain schemes use the opposite of reverse
+        return (scheme == AcquisitionScheme.ECHO_ANTIECHO || scheme == AcquisitionScheme.STATES_TPPI) != reverse;
     }
 
     @Override


### PR DESCRIPTION
For Echo-AntiEcho and States-tppi, the inverse of whatever was in f1 reverse resulted in the correct spectrum

Switched to check for $SFO1 as sf label first, 

Note: JRES experiment still does not load correctly but it seems to be a result of the test file not having the correct Acquisition Scheme