### PR TITLE
Nmr 5313 export png exports blank image

### DIFF
--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -853,12 +853,18 @@ public class FXMLController implements  Initializable, PeakNavigable {
         FileChooser fileChooser = new FileChooser();
         fileChooser.setTitle("Export to PNG");
         fileChooser.setInitialDirectory(getInitialDirectory());
+        fileChooser.getExtensionFilters().addAll(
+                new ExtensionFilter("PNG (*.png)", "*.png"),
+                new ExtensionFilter("All Files", "*.*"));
         File selectedFile = fileChooser.showSaveDialog(null);
         if (selectedFile != null) {
             try {
-                GUIUtils.snapNode(chartGroup, selectedFile);
+                plotContent.setVisible(false);
+                GUIUtils.snapNode(chartPane, selectedFile);
             } catch (IOException ex) {
                 GUIUtils.warn("Error saving png file", ex.getLocalizedMessage());
+            } finally {
+                plotContent.setVisible(true);
             }
         }
     }
@@ -868,8 +874,13 @@ public class FXMLController implements  Initializable, PeakNavigable {
         FileChooser fileChooser = new FileChooser();
         fileChooser.setTitle("Export to PDF");
         fileChooser.setInitialDirectory(getInitialDirectory());
+        fileChooser.getExtensionFilters().addAll(
+                new ExtensionFilter("PDF (*.pdf)", "*.pdf"),
+                new ExtensionFilter("All Files", "*.*"));
         File selectedFile = fileChooser.showSaveDialog(null);
-        exportPDF(selectedFile);
+        if (selectedFile != null) {
+            exportPDF(selectedFile);
+        }
     }
 
     public void exportPDF(File file) {
@@ -897,8 +908,13 @@ public class FXMLController implements  Initializable, PeakNavigable {
         FileChooser fileChooser = new FileChooser();
         fileChooser.setTitle("Export to SVG");
         fileChooser.setInitialDirectory(getInitialDirectory());
+        fileChooser.getExtensionFilters().addAll(
+                new ExtensionFilter("SVG (*.svg)", "*.svg"),
+                new ExtensionFilter("All Files", "*.*"));
         File selectedFile = fileChooser.showSaveDialog(null);
-        exportSVG(selectedFile);
+        if (selectedFile != null) {
+            exportSVG(selectedFile);
+        }
     }
 
     public void exportSVG(File file) {

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -79,6 +79,7 @@ import org.nmrfx.processor.gui.controls.GridPaneCanvas;
 import org.nmrfx.processor.gui.spectra.*;
 import org.nmrfx.processor.gui.tools.SpectrumComparator;
 import org.nmrfx.processor.gui.undo.UndoManager;
+import org.nmrfx.processor.gui.utils.FileExtensionFilterType;
 import org.nmrfx.utilities.DictionarySort;
 import org.nmrfx.utils.GUIUtils;
 import org.python.core.PyObject;
@@ -404,8 +405,8 @@ public class FXMLController implements  Initializable, PeakNavigable {
         fileChooser.setInitialDirectory(getInitialDirectory());
         fileChooser.setTitle("Open NMR FID");
         fileChooser.getExtensionFilters().addAll(
-                new ExtensionFilter("NMR Fid", "fid", "ser", "*.nv", "*.dx", "*.jdx", "*.jdf", "*.dat"),
-                new ExtensionFilter("Any File", "*.*")
+                FileExtensionFilterType.NMR_FID.getFilter(),
+                FileExtensionFilterType.ALL_FILES.getFilter()
         );
         File selectedFile = fileChooser.showOpenDialog(null);
         if (selectedFile != null) {
@@ -421,8 +422,8 @@ public class FXMLController implements  Initializable, PeakNavigable {
         fileChooser.setInitialDirectory(getInitialDirectory());
         fileChooser.setTitle("Open NMR Dataset");
         fileChooser.getExtensionFilters().addAll(
-                new ExtensionFilter("NMR Dataset", "*.nv", "*.ucsf", "*.dx", "*.jdx", "1r", "2rr", "3rrr", "4rrrr", RS2DData.DATA_FILE_NAME),
-                new ExtensionFilter("Any File", "*.*")
+                FileExtensionFilterType.NMR_DATASET.getFilter(),
+                FileExtensionFilterType.ALL_FILES.getFilter()
         );
         File selectedFile = fileChooser.showOpenDialog(null);
         openDataset(selectedFile, false);
@@ -471,8 +472,8 @@ public class FXMLController implements  Initializable, PeakNavigable {
         fileChooser.setInitialDirectory(getInitialDirectory());
         fileChooser.setTitle("Add NMR FID/Dataset");
         fileChooser.getExtensionFilters().addAll(
-                new ExtensionFilter("NMR Fid", "fid", "ser", "*.nv", "*.dx", "*.jdx"),
-                new ExtensionFilter("Any File", "*.*")
+                FileExtensionFilterType.NMR_FID.getFilter(),
+                FileExtensionFilterType.ALL_FILES.getFilter()
         );
         File selectedFile = fileChooser.showOpenDialog(null);
         if (selectedFile != null) {
@@ -488,8 +489,8 @@ public class FXMLController implements  Initializable, PeakNavigable {
         fileChooser.setInitialDirectory(getInitialDirectory());
         fileChooser.setTitle("Add NMR Dataset");
         fileChooser.getExtensionFilters().addAll(
-                new ExtensionFilter("NMR Dataset", "*.nv", "*.ucsf"),
-                new ExtensionFilter("Any File", "*.*")
+                FileExtensionFilterType.NMR_DATASET.getFilter(),
+                FileExtensionFilterType.ALL_FILES.getFilter()
         );
         List<File> selectedFiles = fileChooser.showOpenMultipleDialog(null);
         if (selectedFiles != null) {
@@ -854,8 +855,9 @@ public class FXMLController implements  Initializable, PeakNavigable {
         fileChooser.setTitle("Export to PNG");
         fileChooser.setInitialDirectory(getInitialDirectory());
         fileChooser.getExtensionFilters().addAll(
-                new ExtensionFilter("PNG (*.png)", "*.png"),
-                new ExtensionFilter("All Files", "*.*"));
+                FileExtensionFilterType.PNG.getFilter(),
+                FileExtensionFilterType.ALL_FILES.getFilter()
+        );
         File selectedFile = fileChooser.showSaveDialog(null);
         if (selectedFile != null) {
             try {
@@ -875,8 +877,9 @@ public class FXMLController implements  Initializable, PeakNavigable {
         fileChooser.setTitle("Export to PDF");
         fileChooser.setInitialDirectory(getInitialDirectory());
         fileChooser.getExtensionFilters().addAll(
-                new ExtensionFilter("PDF (*.pdf)", "*.pdf"),
-                new ExtensionFilter("All Files", "*.*"));
+                FileExtensionFilterType.PDF.getFilter(),
+                FileExtensionFilterType.ALL_FILES.getFilter()
+        );
         File selectedFile = fileChooser.showSaveDialog(null);
         if (selectedFile != null) {
             exportPDF(selectedFile);
@@ -909,8 +912,9 @@ public class FXMLController implements  Initializable, PeakNavigable {
         fileChooser.setTitle("Export to SVG");
         fileChooser.setInitialDirectory(getInitialDirectory());
         fileChooser.getExtensionFilters().addAll(
-                new ExtensionFilter("SVG (*.svg)", "*.svg"),
-                new ExtensionFilter("All Files", "*.*"));
+                FileExtensionFilterType.SVG.getFilter(),
+                FileExtensionFilterType.ALL_FILES.getFilter()
+        );
         File selectedFile = fileChooser.showSaveDialog(null);
         if (selectedFile != null) {
             exportSVG(selectedFile);

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/utils/FileExtensionFilterType.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/utils/FileExtensionFilterType.java
@@ -1,0 +1,33 @@
+package org.nmrfx.processor.gui.utils;
+
+import javafx.stage.FileChooser.ExtensionFilter;
+import org.nmrfx.processor.datasets.vendor.rs2d.RS2DData;
+
+import java.util.List;
+
+/**
+ * Enum to keep file chooser extension descriptions consistent for each set of extension filter.
+ */
+public enum FileExtensionFilterType {
+    ALL_FILES("All Files", "*.*"),
+    NMR_FID("NMR Fid","fid", "ser", "*.nv", "*.dx", "*.jdx", "*.jdf", "*.dat"),
+    NMR_DATASET("NMR Dataset", "*.nv", "*.ucsf", "*.dx", "*.jdx", "1r", "2rr", "3rrr", "4rrrr", RS2DData.DATA_FILE_NAME),
+    PDF("PDF", "*.pdf"),
+    PNG("PNG", "*.png"),
+    SVG("SVG", "*.svg");
+
+    private final String description;
+    private final List<String> filters;
+
+    FileExtensionFilterType(String description, String... filters) {
+        this.description = description;
+        this.filters = List.of(filters);
+    }
+
+    public ExtensionFilter getFilter() {
+        return new ExtensionFilter(description, filters);
+    }
+}
+
+
+


### PR DESCRIPTION
Exporting a blank png seems to have started when PolyChart was switched to extending a Node (https://github.com/nanalysis/nmrfx/pull/60). It seems like javafx Node.snapshot only takes a snapshot of whatever is both stored in a nodes children and is visible (and in the children's children etc).  The chartGroup object contains PolyChart objects as its children but the PolyChart objects don't have any children, therefore only a blank image was produced. The canvases can't be set to be the children of the PolyChart because nodes can only have one parent and there is more than one PolyChart but only one of each canvas. The chartPane object has the canvases as its children so using it for the snapshot will save the content, but the cursor lines must be disabled before snapshot and reenabled afterwards.