### PR TITLE
NMR-5366 opening multiplet tool for 2D causes multiple errors

### DIFF
--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/AnalystApp.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/AnalystApp.java
@@ -384,7 +384,7 @@ public class AnalystApp extends MainApp {
 
     @Override
     public void addStatusBarTools(SpectrumStatusBar statusBar) {
-        Menu oneDMenu = new Menu("Analysis (1D)");
+        Menu oneDMenu = new Menu(SpectrumStatusBar.ANALYSIS_1D_MENU_STRING );
         MenuItem multipletToolItem = new MenuItem("Show Multiplet Tool");
         multipletToolItem.setOnAction(e -> showMultipletTool());
 
@@ -482,6 +482,7 @@ public class AnalystApp extends MainApp {
         Button wizardButton = GlyphsDude.createIconButton(FontAwesomeIcon.MAGIC, "Multiplets", iconSize, fontSize, ContentDisplay.LEFT);
         wizardButton.setOnAction(e -> simplePeakRegionTool.analyzeMultiplets());
         statusBar.addToolBarButtons(regionButton, peakButton, wizardButton);
+         controller.addTool(simplePeakRegionTool);
     }
 
 
@@ -675,6 +676,8 @@ public class AnalystApp extends MainApp {
         FXMLController controller = FXMLController.getActiveController();
         controller.removeTool(RegionTool.class);
         controller.getBottomBox().getChildren().remove(regionTool.getBox());
+        // Must remove all listeners that the region tool set, or they will continue to be called.
+        regionTool.removeListeners();
     }
 
     public void showPeakPathTool() {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/SimplePeakRegionTool.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/SimplePeakRegionTool.java
@@ -6,6 +6,7 @@ import org.nmrfx.analyst.peaks.Analyzer;
 import org.nmrfx.datasets.DatasetRegion;
 import org.nmrfx.peaks.PeakList;
 import org.nmrfx.processor.datasets.Dataset;
+import org.nmrfx.processor.gui.AnalyzerTool;
 import org.nmrfx.processor.gui.ControllerTool;
 import org.nmrfx.processor.gui.FXMLController;
 import org.nmrfx.processor.gui.PeakPicking;
@@ -20,7 +21,7 @@ import java.util.Set;
 
 import static org.nmrfx.utils.GUIUtils.affirm;
 
-public class SimplePeakRegionTool implements ControllerTool {
+public class SimplePeakRegionTool implements ControllerTool, AnalyzerTool {
     private static final Logger log = LoggerFactory.getLogger(SimplePeakRegionTool.class);
     Analyzer analyzer;
     FXMLController controller;
@@ -41,27 +42,43 @@ public class SimplePeakRegionTool implements ControllerTool {
         return chart;
     }
 
+    /**
+     * Updates the tool's chart and analyzer.
+     */
+    public void updateTool() {
+        getAnalyzer();
+    }
+
+    /**
+     * Gets the currently active chart and sets the analyzer based on the chart's
+     * dataset.
+     */
     public Analyzer getAnalyzer() {
+        chart = getChart();
+        Dataset dataset = (Dataset) chart.getDataset();
         if (analyzer == null) {
-            chart = getChart();
-            Dataset dataset = (Dataset) chart.getDataset();
             if ((dataset == null) || (dataset.getNDim() > 1)) {
-                Alert alert = new Alert(Alert.AlertType.ERROR);
-                alert.setContentText("Chart must have a 1D dataset");
-                alert.showAndWait();
-                return null;
+                analyzer = null;
+                return analyzer;
             }
             analyzer = new Analyzer(dataset);
-            if (!chart.getPeakListAttributes().isEmpty()) {
-                analyzer.setPeakList(chart.getPeakListAttributes().get(0).getPeakList());
+        }  else {
+            if (dataset == null || dataset.getNDim() > 1){
+                analyzer = null;
+                return analyzer;
             }
+            if (analyzer.getDataset() != dataset && dataset.getNDim() <= 1) {
+                analyzer = new Analyzer(dataset);
+            }
+        }
+        if (!chart.getPeakListAttributes().isEmpty()) {
+            analyzer.setPeakList(chart.getPeakListAttributes().get(0).getPeakList());
         }
         return analyzer;
     }
 
     public void clearAnalysis(boolean prompt) {
         if (!prompt || affirm("Clear Analysis")) {
-            Analyzer analyzer = getAnalyzer();
             if (analyzer != null) {
                 PeakList peakList = analyzer.getPeakList();
                 if (peakList != null) {
@@ -75,16 +92,25 @@ public class SimplePeakRegionTool implements ControllerTool {
         }
     }
 
+    private void invalidDatasetAlert(String message) {
+        Alert alert = new Alert(Alert.AlertType.ERROR);
+        alert.setContentText(message);
+        alert.showAndWait();
+    }
+
     public boolean hasRegions() {
-        Set<DatasetRegion> regions = chart.getDataset().getRegions();
-        return (regions != null) && !regions.isEmpty();
+        Dataset dataset = (Dataset) chart.getDataset();
+        if (dataset != null) {
+            Set<DatasetRegion> regions = dataset.getRegions();
+            return (regions != null) && !regions.isEmpty();
+        }
+        return false;
     }
 
     public void findRegions() {
         if (hasRegions()) {
             clearAnalysis(true);
         }
-        Analyzer analyzer = getAnalyzer();
         if (analyzer != null) {
             analyzer.calculateThreshold();
             analyzer.getThreshold();
@@ -102,21 +128,21 @@ public class SimplePeakRegionTool implements ControllerTool {
                 // normalize to the smallest integral, but don't count very small integrals (less than 0.001 of max
                 // to avoid artifacts
 
-                double threshold = regions.stream().mapToDouble(r -> r.getIntegral()).max().orElse(1.0) / 1000.0;
-                regions.stream().mapToDouble(r -> r.getIntegral()).filter(r -> r > threshold).min().ifPresent(min -> {
-                    dataset.setNorm(min * dataset.getScale() / 1.0);
-                });
+                double threshold = regions.stream().mapToDouble(DatasetRegion::getIntegral).max().orElse(1.0) / 1000.0;
+                regions.stream().mapToDouble(DatasetRegion::getIntegral).filter(r -> r > threshold).min().ifPresent(
+                        min -> dataset.setNorm(min * dataset.getScale()));
             }
             chart.refresh();
             chart.chartProps.setRegions(true);
             chart.chartProps.setIntegrals(true);
             chart.setActiveRegion(null);
             chart.refresh();
+        } else {
+            invalidDatasetAlert("Chart must have a 1D dataset.");
         }
 
     }
     public void peakPick() {
-        Analyzer analyzer = getAnalyzer();
         if (analyzer != null) {
             Set<DatasetRegion> regions = chart.getDataset().getRegions();
             if ((regions == null) || regions.isEmpty()) {
@@ -139,12 +165,13 @@ public class SimplePeakRegionTool implements ControllerTool {
             peakList.setProperty("minWidth", String.valueOf(minWidth));
             peakList.setProperty("maxWidth", String.valueOf(maxWidth));
             chart.refresh();
+        } else {
+            invalidDatasetAlert("Chart must have a valid dataset.");
         }
 
     }
 
     public void analyzeMultiplets() {
-        Analyzer analyzer = getAnalyzer();
         if (analyzer != null) {
             try {
                 analyzer.analyze();
@@ -158,6 +185,8 @@ public class SimplePeakRegionTool implements ControllerTool {
             } catch (IOException ex) {
                 log.error(ex.getMessage(), ex);
             }
+        } else {
+            invalidDatasetAlert("Chart must have a 1D dataset.");
         }
     }
 

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/AnalyzerTool.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/AnalyzerTool.java
@@ -1,0 +1,8 @@
+package org.nmrfx.processor.gui;
+
+/**
+ * Interface for tools that use the Analyzer class.
+ */
+public interface AnalyzerTool {
+    void updateTool();
+}

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -284,6 +284,9 @@ public class FXMLController implements  Initializable, PeakNavigable {
     public void setActiveChart(PolyChart chart) {
         if (activeChart != chart) {
             deselectCharts();
+        } else {
+            // if previous active chart is the same as the new active chart, do nothing
+            return;
         }
         isFID = false;
         activeChart = chart;
@@ -304,6 +307,16 @@ public class FXMLController implements  Initializable, PeakNavigable {
         }
         if (statusBar != null) {
             statusBar.setChart(activeChart);
+        }
+        updateControllerTools();
+    }
+
+    private void updateControllerTools() {
+        List<ControllerTool> toolList = new ArrayList<>(getTools());
+        for (ControllerTool tool: toolList) {
+            if (tool instanceof AnalyzerTool) {
+                ((AnalyzerTool) tool).updateTool();
+            }
         }
     }
 
@@ -665,7 +678,7 @@ public class FXMLController implements  Initializable, PeakNavigable {
         borderPane.setLeft(null);
         borderPane.setBottom(null);
         updateSpectrumStatusBarOptions();
-
+        updateControllerTools();
         phaser.getPhaseOp();
         if (!reload) {
             if (!datasetAttributes.getHasLevel()) {
@@ -688,6 +701,8 @@ public class FXMLController implements  Initializable, PeakNavigable {
     private void updateSpectrumStatusBarOptions() {
         if (isFIDActive()) {
             statusBar.setMode(0);
+        } else if (getActiveChart().getDataset() == null) {
+            statusBar.disable1DAnalysisTools(true);
         } else {
             ObservableList<DatasetAttributes> datasetAttrList = getActiveChart().getDatasetAttributes();
             OptionalInt maxNDim = datasetAttrList.stream().mapToInt(d -> d.nDim).max();
@@ -1219,6 +1234,7 @@ public class FXMLController implements  Initializable, PeakNavigable {
 
         controllers.add(this);
         statusBar.setMode(1);
+        statusBar.disable1DAnalysisTools(true);
         activeController.set(this);
         for (int iCross = 0; iCross < 2; iCross++) {
             for (int jOrient = 0; jOrient < 2; jOrient++) {

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -222,6 +222,10 @@ public class PolyChart extends Region implements PeakListener {
         selectedMultiplets.addListener(listener);
     }
 
+    public void removeMultipletListener(SetChangeListener listener) {
+        selectedMultiplets.removeListener(listener);
+    }
+
     public void setPeakStatus(boolean state) {
         peakStatus.set(state);
     }

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -218,11 +218,11 @@ public class PolyChart extends Region implements PeakListener {
         }
     }
 
-    public void addMultipletListener(SetChangeListener listener) {
+    public void addMultipletListener(SetChangeListener<MultipletSelection> listener) {
         selectedMultiplets.addListener(listener);
     }
 
-    public void removeMultipletListener(SetChangeListener listener) {
+    public void removeMultipletListener(SetChangeListener<MultipletSelection> listener) {
         selectedMultiplets.removeListener(listener);
     }
 

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/SpectrumStatusBar.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/SpectrumStatusBar.java
@@ -65,7 +65,7 @@ import org.nmrfx.processor.gui.undo.ChartUndoLimits;
  * @author Bruce Johnson
  */
 public class SpectrumStatusBar {
-
+    public static final String ANALYSIS_1D_MENU_STRING = "Analysis (1D)";
     static final DecimalFormat formatter = new DecimalFormat();
 
     static {
@@ -551,6 +551,7 @@ public class SpectrumStatusBar {
 
         btoolBar.getItems().addAll(nodes);
         updateRowSpinner(0, 1);
+        disable1DAnalysisTools(true);
 
     }
 
@@ -606,7 +607,16 @@ public class SpectrumStatusBar {
         btoolBar.getItems().clear();
 
         btoolBar.getItems().addAll(nodes);
+        disable1DAnalysisTools(mode != 1);
 
+    }
+
+    public void disable1DAnalysisTools(boolean disable) {
+        for (MenuItem menuItem: toolButton.getItems()) {
+            if (ANALYSIS_1D_MENU_STRING.equals(menuItem.getText())) {
+                menuItem.setDisable(disable);
+            }
+        }
     }
 
     public void setCrossText(int iOrient, int iCross, Double value, boolean iconState) {


### PR DESCRIPTION
Multiple messages/tools were a result of calling `getAnalyzer` on each button press without a null check. For example the initMultiplet resulted in 3 calls to getAnalyzer which resulted in three identical popup warnings. The regions tool had similar issues. Additionally only some multiplet buttons gave error popups, others resulted in NPE or ran on a previously loaded dataset as getAnalyzer was not called at the start of every method.
This pr:
- Updates analyzer when dataset is opened/active chart changed so it should always be up to date
- adds missing null checks to avoid NPE
- Disables the 1D menu option so region and multiplet tool cannot be accessed when a non 1D datataset is displayed *VISIBLE BEHAVIOUR CHANGE*
- Closes the tool if an incompatible dataset is loaded *VISIBLE BEHAVIOUR CHANGE*