### PR TITLE
NMR-5271: clear undo manager when a new dataset is loaded

### DIFF
--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -690,6 +690,7 @@ public class FXMLController implements  Initializable, PeakNavigable {
             }
         }
         getActiveChart().layoutPlotChildren();
+        undoManager.clear();
     }
 
     /**


### PR DESCRIPTION
The undo queue wasn't cleared when new datasets were loaded, so the queue could contain undo elements with the wrong dimensions since the previous dataset might not have had the same dimensions resulting in an out of bounds exceptions.