### PR TITLE
NMR-5272: use the fpath to determine if BrukerData is an FID instead …

### DIFF
--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/bruker/BrukerData.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/bruker/BrukerData.java
@@ -91,6 +91,8 @@ public class BrukerData implements NMRData {
     private String[] acqOrder;
     private SampleSchedule sampleSchedule = null;
     private final double scale;
+    // flag to indicate BrukerData has been opened as an FID
+    private boolean isFID;
     boolean hasFID = false;
     boolean hasSpectrum = false;
     List<Double> arrayValues = new ArrayList<>();
@@ -109,7 +111,7 @@ public class BrukerData implements NMRData {
         }
         this.fpath = path;
         this.nusFile = nusFile;
-        hasFID = findFIDFiles(this.fpath);
+        isFID = true;
         File file = new File(path);
         openParFile(file);
         openDataFile(path);
@@ -129,7 +131,7 @@ public class BrukerData implements NMRData {
         File file = new File(path);
         this.fpath = path;
         this.nusFile = null;
-        hasFID = findFIDFiles(this.fpath);
+        isFID = false;
         openParFile(file.getParentFile().getParentFile().getParentFile());
         scale = 1.0;
     }
@@ -1822,7 +1824,7 @@ public class BrukerData implements NMRData {
 
     @Override
     public boolean isFID() {
-        return hasFID;
+        return isFID;
     }
 
     @Override

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/bruker/BrukerData.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/bruker/BrukerData.java
@@ -109,6 +109,7 @@ public class BrukerData implements NMRData {
         }
         this.fpath = path;
         this.nusFile = nusFile;
+        hasFID = findFIDFiles(this.fpath);
         File file = new File(path);
         openParFile(file);
         openDataFile(path);
@@ -128,6 +129,7 @@ public class BrukerData implements NMRData {
         File file = new File(path);
         this.fpath = path;
         this.nusFile = null;
+        hasFID = findFIDFiles(this.fpath);
         openParFile(file.getParentFile().getParentFile().getParentFile());
         scale = 1.0;
     }
@@ -1820,7 +1822,7 @@ public class BrukerData implements NMRData {
 
     @Override
     public boolean isFID() {
-        return findFIDFiles(fpath);
+        return hasFID;
     }
 
     @Override

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/bruker/BrukerData.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/bruker/BrukerData.java
@@ -1820,7 +1820,7 @@ public class BrukerData implements NMRData {
 
     @Override
     public boolean isFID() {
-        return !isFrequencyDim(0);
+        return findFIDFiles(fpath);
     }
 
     @Override


### PR DESCRIPTION
…of isFrequencyDim

Unable to load any ser files as FID, switched to checking to see if the filenames exist at the filepath