### PR TITLE
Nmr 5448 halting processing can cause exception on next load and process

### DIFF
--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ChartProcessor.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ChartProcessor.java
@@ -1252,9 +1252,9 @@ public class ChartProcessor {
             complex[iDim] = data.isComplex(iDim);
         }
         processorController.updateDimChoice(complex);
-        reloadData();
         processorController.refManager.resetData();
         processorController.refManager.setupItems(0);
+        reloadData();
         processorController.updateParTable(data);
         if (!clearOps) {
             setScripts(saveHeaderList, listOfScripts);

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ProcessorController.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ProcessorController.java
@@ -963,6 +963,7 @@ public class ProcessorController implements Initializable, ProgressUpdater {
             ((Service<Integer>) worker).setOnCancelled(event -> {
                 setProcessingOff();
                 setProcessingStatus("cancelled", false);
+                Processor.getProcessor().closeDataset(false);
             });
             ((Service<Integer>) worker).setOnFailed(event -> {
                 setProcessingOff();

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/processing/Processor.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/processing/Processor.java
@@ -1446,7 +1446,7 @@ public class Processor {
             if (!dataset.isMemoryFile()) {
                 dataset.writeParFile();
             }
-            closeDataset();
+            closeDataset(true);
         }
         String elapsedTimeStr = String.format("Elapsed time %.2f", elapsedTime);
         log.info(elapsedTimeStr);
@@ -1465,9 +1465,9 @@ public class Processor {
         simVecProcessor.saveSimFids();
     }
 
-    public void closeDataset() {
+    public void closeDataset(boolean saveDataset) {
         if (dataset != null) {
-            if (dataset.isMemoryFile()) {
+            if (dataset.isMemoryFile() && saveDataset) {
                 try {
                     if (dataset.getFileName().endsWith(RS2DData.DATA_FILE_NAME) && (getNMRData() instanceof RS2DData)) {
                         RS2DData rs2DData = (RS2DData) getNMRData();
@@ -1577,8 +1577,7 @@ public class Processor {
             isRunning = false;
             if (getProcessorError()) {
                 setProcessorAvailableStatus(true);
-                dataset.close();
-                dataset = null;
+                closeDataset(false);
                 throw new ProcessingException(errorMessage.get());
             }
         }


### PR DESCRIPTION
There were two separate issues:
1. On halt, the dataset was not always being closed, and trying to process a new FID would not create a new dataset since there was one already open. (stacktrace in HMBC-COSY.txt)
2. Loading files with different variable names for sw/sf resulted in an exception (stacktrace in hnconus-1H1d.txt)