### PR TITLE
NMR-4506: store svg clipboard content as ByteBuffer

### DIFF
--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/spectra/SpectrumMenuActions.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/spectra/SpectrumMenuActions.java
@@ -59,7 +59,7 @@ public class SpectrumMenuActions extends MenuActions {
         arrangeMenu.getItems().addAll(createGridItem, horizItem, vertItem, gridItem, overlayItem, minimizeItem, normalizeItem);
         MenuItem favoritesMenuItem = new MenuItem("Favorites");
         favoritesMenuItem.setOnAction(e -> showFavorites());
-        MenuItem copyItem = new MenuItem("Copy Spectrum as SVG Text");
+        MenuItem copyItem = new MenuItem("Copy Spectrum as SVG");
         copyItem.setOnAction(e -> FXMLController.getActiveController().copySVGAction(e));
         menu.getItems().addAll(newMenuItem, deleteItem, arrangeMenu, favoritesMenuItem, syncMenuItem, copyItem);
         MenuItem[] disableItems = {deleteItem, arrangeMenu, favoritesMenuItem, syncMenuItem, copyItem};

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -95,7 +95,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -1008,8 +1008,7 @@ public class FXMLController implements  Initializable, PeakNavigable {
             if (svgFormat == null) {
                 svgFormat = new DataFormat("image/svg+xml");
             }
-            content.put(svgFormat, stream.toString().getBytes(StandardCharsets.UTF_8));
-            content.put(DataFormat.PLAIN_TEXT, stream.toString());
+            content.put(svgFormat, ByteBuffer.wrap(stream.toByteArray()));
             clipboard.setContent(content);
         } catch (GraphicsIOException ex) {
             ExceptionDialog eDialog = new ExceptionDialog(ex);

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -1009,6 +1009,7 @@ public class FXMLController implements  Initializable, PeakNavigable {
                 svgFormat = new DataFormat("image/svg+xml");
             }
             content.put(svgFormat, ByteBuffer.wrap(stream.toByteArray()));
+            content.put(DataFormat.PLAIN_TEXT, stream.toString());
             clipboard.setContent(content);
         } catch (GraphicsIOException ex) {
             ExceptionDialog eDialog = new ExceptionDialog(ex);

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/MainApp.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/MainApp.java
@@ -317,7 +317,7 @@ public class MainApp extends Application {
                 recentFIDMenuItem, recentDatasetMenuItem, newMenuItem, new SeparatorMenuItem(), pdfMenuItem, svgMenuItem, pngMenuItem, loadPeakListMenuItem);
 
         Menu spectraMenu = new Menu("Spectra");
-        MenuItem copyItem = new MenuItem("Copy Spectrum as SVG Text");
+        MenuItem copyItem = new MenuItem("Copy Spectrum as SVG");
         copyItem.setOnAction(e -> FXMLController.getActiveController().copySVGAction(e));
         MenuItem deleteItem = new MenuItem("Delete Spectrum");
         deleteItem.setOnAction(e -> FXMLController.getActiveController().getActiveChart().close());


### PR DESCRIPTION
Can copy and paste into desktop app Word (Office 365) on windows. (Right click after pasting to convert to shape and components can be moved around)

Can copy and paste into Inkscape (tested on Linux)

Note: Copy and paste does not work with online versions of Word (Office 365) which seems to have more limited copy and paste options: (https://support.microsoft.com/en-us/office/copy-and-paste-in-office-for-the-web-682704da-8360-464c-9a26-ff44abf4c4fe#__word_web_app)