### PR TITLE
NMR-5198: add vm option to fix autocompletion binding to .bat files i…

### DIFF
--- a/nmrfx-analyst-gui/src/main/scripts/nmrfx.bat
+++ b/nmrfx-analyst-gui/src/main/scripts/nmrfx.bat
@@ -20,6 +20,7 @@ set dir=%~dp0
 
 set javaexe=java
 set cp="%dir%nmrfx-analyst-gui-%nvjver%.jar;%dir%lib/Manifest.jar;%dir%plugins/*"
+set JAVA_OPTS="--add-exports=javafx.base/com.sun.javafx.event=ALL-UNNAMED"
 
 set testjava="%dir%jre\bin\java.exe"
 

--- a/nmrfx-processor-gui/src/main/scripts/nmrfxpg.bat
+++ b/nmrfx-processor-gui/src/main/scripts/nmrfxpg.bat
@@ -19,7 +19,7 @@ set dir=%~dp0
 
 set javaexe=java
 set cp="%dir%nmrfx-processor-gui-%nvjver%.jar;%dir%lib/Manifest.jar"
-
+set JAVA_OPTS="--add-exports=javafx.base/com.sun.javafx.event=ALL-UNNAMED"
 
 set testjava="%dir%jre\bin\java.exe"
 


### PR DESCRIPTION
…n analyst-gui and processor-gui


Set JAVA_OPTS for the .bat files in the analyst-gui and processor-gui packages. This exception with the AutoCompletionBinding only seems to occur in windows, not linux so did not add anything to the bash scripts. Should be tested with mac though.


Related to this pr: https://github.com/nanalysis/nmrfx-private/pull/21