### PR TITLE
Nmr 5543 cannot select peaks after peak slider tool opened

### DIFF
--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/AnalystApp.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/AnalystApp.java
@@ -611,6 +611,7 @@ public class AnalystApp extends MainApp {
         FXMLController controller = FXMLController.getActiveController();
         controller.removeTool(PeakSlider.class);
         controller.getBottomBox().getChildren().remove(peakSlider.getBox());
+        peakSlider.removeListeners();
     }
 
     public void showPeakPathTool() {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/PeakSlider.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/PeakSlider.java
@@ -542,11 +542,6 @@ public class PeakSlider implements ControllerTool {
             tweakFreezeButton.setDisable(true);
             linkButton.setDisable(true);
             unlinkButton.setDisable(false);
-            controller.getCharts().stream()
-                    .forEach(chart -> {
-                        chart.clearPeakPaths();
-                        chart.drawPeakLists(true);
-                    });
         } else {
             // fixme axes could be swapped
             Peak peak = peaks.get(peaks.size() - 1);
@@ -595,7 +590,6 @@ public class PeakSlider implements ControllerTool {
                                         });
                                     }
                                 }
-                                chart.drawPeakLists(true);
                             }
                         }
                     });

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/KeyBindings.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/KeyBindings.java
@@ -80,6 +80,10 @@ public class KeyBindings {
         keyActionMap.put(keyString, action);
     }
 
+    public void deregisterKeyAction(String keyString) {
+        keyActionMap.remove(keyString);
+    }
+
     public void keyPressed(KeyEvent keyEvent) {
         KeyCode code = keyEvent.getCode();
         if (null != code) {


### PR DESCRIPTION
There were two sorts of issues:
1. When the peak slider tool was closed, the listeners weren't removed so setActivePeaks, which was drawing the peaks without selection, would end up be called after the selected peaks were drawn.
- fix -> remove listeners

The setActivePeaks method was drawing the peaks without selection so if the peak slider was open, selecting a multiplet arm would not show up as selected, even though it was selected and the popup multiplet tool would delete it.
- fix -> Dont call draw peaks in setActivePeaks method.