### PR TITLE
NMR-5452: don't try to delete peaks from integral if there are no peaks

### DIFF
--- a/nmrfx-analyst/src/main/java/org/nmrfx/analyst/peaks/Analyzer.java
+++ b/nmrfx-analyst/src/main/java/org/nmrfx/analyst/peaks/Analyzer.java
@@ -399,6 +399,9 @@ public class Analyzer {
      * @param region The DatasetRegion to search
      */
     public void removePeaksFromRegion(DatasetRegion region) {
+        if (peakList == null) {
+            return;
+        }
         int[] dim = new int[peakList.nDim];
         for (int i = 0; i < dim.length; i++) {
             dim[i] = i;


### PR DESCRIPTION
Could only delete integrals with Analyzer, since there was no null check for deleting from Integrate where there were no peaks.