### PR TITLE
NMR-5674: set the filename with the pythoninterpreter set method inst…

### DIFF
--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/WindowIO.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/WindowIO.java
@@ -267,7 +267,8 @@ public class WindowIO implements FileWatchListener {
         interp.exec("import nwyaml\\n");
         FXMLController activeController = GUIScripter.getController();
         GUIScripter.setController(controller);
-        interp.exec("nwyaml.dumpYamlWin('" + path.toString() + "')");
+        interp.set("yamlFileName", path.toString());
+        interp.exec("nwyaml.dumpYamlWin(yamlFileName)");
         GUIScripter.setController(activeController);
     }
 


### PR DESCRIPTION
…ead of exec when favoriting a dataset


windows was interpretting some of the characters in the path as special characters ex. \t as tab

Used the same solution as the other methods passing paths to the pythoninterpreter in WindowIO