### PR TITLE
Nmr 5707 jcamp spinlab datasets not saved in projects

### DIFF
--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/SimplePeakRegionTool.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/SimplePeakRegionTool.java
@@ -229,21 +229,7 @@ public class SimplePeakRegionTool implements ControllerTool, PeakListener {
             Set<DatasetRegion> regions = chart.getDataset().getRegions();
             Dataset dataset = (Dataset) chart.getDataset();
             if (!regions.isEmpty()) {
-                // normalize to the smallest integral, but don't count very small integrals (less than 0.001 of max
-                // to avoid artifacts
-
-                double threshold = regions.stream().mapToDouble(DatasetRegion::getIntegral).max().orElse(1.0) / 1000.0;
-                OptionalDouble min = regions.stream().mapToDouble(DatasetRegion::getIntegral).filter(r -> r > threshold).min();
-                if (min.isEmpty()) {
-                    // if all the integrals are negative, get the smallest absolute value
-                    min = regions.stream().mapToDouble(r -> Math.abs(r.getIntegral())).filter(r -> r > threshold).min();
-                }
-                if (min.isPresent()) {
-                    // Save absolute value as the norm, so that spectra with all negative integrals will appear consistent
-                    // with mixed and all positive integral spectra
-                    dataset.setNorm(min.getAsDouble() * dataset.getScale());
-                }
-
+                dataset.setNormFromRegions(regions);
             }
             chart.refresh();
             chart.chartProps.setRegions(true);

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/SimplePeakRegionTool.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/SimplePeakRegionTool.java
@@ -33,7 +33,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.OptionalDouble;
 import java.util.Set;
 import java.util.TreeSet;
 

--- a/nmrfx-analyst/src/test/java/org/nmrfx/analyst/peaks/AnalyzerTest.java
+++ b/nmrfx-analyst/src/test/java/org/nmrfx/analyst/peaks/AnalyzerTest.java
@@ -7,7 +7,6 @@ import org.nmrfx.peaks.PeakList;
 import org.nmrfx.processor.datasets.Dataset;
 import org.nmrfx.processor.datasets.DatasetException;
 
-import java.io.IOException;
 
 public class AnalyzerTest extends TestCase {
 

--- a/nmrfx-analyst/src/test/java/org/nmrfx/analyst/peaks/AnalyzerTest.java
+++ b/nmrfx-analyst/src/test/java/org/nmrfx/analyst/peaks/AnalyzerTest.java
@@ -27,7 +27,7 @@ public class AnalyzerTest extends TestCase {
         thirdPeak.getPeakDim(0).setChemShift(4.5F);
         // First and second peak are part of the region
         DatasetRegion region = new DatasetRegion(2, 4);
-        Analyzer analyzer = Analyzer.getAnalyzer(new Dataset("", new int[]{1024}, false));
+        Analyzer analyzer = Analyzer.getAnalyzer(new Dataset("", null, new int[]{1024}, false));
         analyzer.setPeakList(peakList);
 
         // third peak should have id of 2 since it was added third

--- a/nmrfx-core/src/main/java/org/nmrfx/datasets/DatasetBase.java
+++ b/nmrfx-core/src/main/java/org/nmrfx/datasets/DatasetBase.java
@@ -1665,7 +1665,7 @@ public class DatasetBase {
      * integral, without count very small integrals (less than 0.001 of max to avoid artifacts.
      * @param datasetRegions The regions to calculate the norm from.
      */
-    public void setNormFromRegions(Set<DatasetRegion> datasetRegions) {
+    public void setNormFromRegions(Collection<DatasetRegion> datasetRegions) {
         // normalize to the smallest integral, but don't count very small integrals (less than 0.001 of max
         // to avoid artifacts
 

--- a/nmrfx-core/src/main/java/org/nmrfx/datasets/DatasetFactory.java
+++ b/nmrfx-core/src/main/java/org/nmrfx/datasets/DatasetFactory.java
@@ -5,6 +5,9 @@
  */
 package org.nmrfx.datasets;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -15,13 +18,16 @@ import java.lang.reflect.Method;
  * @author brucejohnson
  */
 public class DatasetFactory {
+    private static final Logger log = LoggerFactory.getLogger(DatasetFactory.class);
+
+    private DatasetFactory() {}
 
     public static DatasetBase newDataset(String fullName, String name, boolean writable, boolean useCacheFile) throws IOException {
         DatasetBase dataset;
         try {
-            Class c = Class.forName("org.nmrfx.processor.datasets.Dataset");
-            Class[] parameterTypes = {String.class, String.class, boolean.class, boolean.class};
-            Constructor constructor = c.getDeclaredConstructor(parameterTypes);
+            Class<?> c = Class.forName("org.nmrfx.processor.datasets.Dataset");
+            var parameterTypes = new Class[]{String.class, String.class, boolean.class, boolean.class};
+            Constructor<?> constructor = c.getDeclaredConstructor(parameterTypes);
             dataset = (DatasetBase) constructor.newInstance(fullName, name, writable, useCacheFile);
         } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException ex) {
             dataset = new DatasetBase(fullName, name, writable, useCacheFile);
@@ -29,17 +35,17 @@ public class DatasetFactory {
         return dataset;
     }
 
-    public static DatasetBase newLinkDataset(String name, String fullName) throws IOException {
+    public static DatasetBase newLinkDataset(String name, String fullName)  {
         DatasetBase dataset;
         try {
-            Class c = Class.forName("org.nmrfx.processor.datasets.Dataset");
-            Class[] argTypes = {String.class, String.class};
+            Class<?> c = Class.forName("org.nmrfx.processor.datasets.Dataset");
+            var argTypes = new Class[]{String.class, String.class};
             Method m = c.getDeclaredMethod("newLinkDataset", argTypes);
             String[] args = {name, fullName};
-            System.out.println("new link " + fullName);
-            dataset = (DatasetBase) m.invoke(null, args);
+            log.debug("new link {}", fullName);
+            dataset = (DatasetBase) m.invoke(null, (Object[]) args);
         } catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
-            System.out.println("exc " + ex.getMessage());
+            log.warn(ex.getMessage(), ex);
             dataset = null;
         }
 

--- a/nmrfx-core/src/main/java/org/nmrfx/datasets/DatasetParameterFile.java
+++ b/nmrfx-core/src/main/java/org/nmrfx/datasets/DatasetParameterFile.java
@@ -55,10 +55,10 @@ public class DatasetParameterFile {
     }
 
     public static String getParameterFileName(String fileName) {
-        Pattern pattern = Pattern.compile("(.+)\\.(nv|ucsf|nvlnk)$");
+        Pattern pattern = Pattern.compile(".(nv|ucsf|nvlnk)$");
         Matcher matcher = pattern.matcher(fileName);
-        int extLen = matcher.find() ? matcher.start() : 0;
-        return fileName.substring(0, fileName.length() - extLen) + ".par";
+        int endIndex = matcher.find() ? matcher.start() : fileName.length();
+        return fileName.substring(0, endIndex) + ".par";
     }
 
     public final boolean remove() {

--- a/nmrfx-core/src/main/java/org/nmrfx/datasets/DatasetParameterFile.java
+++ b/nmrfx-core/src/main/java/org/nmrfx/datasets/DatasetParameterFile.java
@@ -55,7 +55,7 @@ public class DatasetParameterFile {
     }
 
     public static String getParameterFileName(String fileName) {
-        Pattern pattern = Pattern.compile(".(nv|ucsf|nvlnk)$");
+        Pattern pattern = Pattern.compile("\\.(nv|ucsf|nvlnk)$");
         Matcher matcher = pattern.matcher(fileName);
         int endIndex = matcher.find() ? matcher.start() : fileName.length();
         return fileName.substring(0, endIndex) + ".par";

--- a/nmrfx-core/src/main/java/org/nmrfx/datasets/DatasetParameterFile.java
+++ b/nmrfx-core/src/main/java/org/nmrfx/datasets/DatasetParameterFile.java
@@ -55,18 +55,10 @@ public class DatasetParameterFile {
     }
 
     public static String getParameterFileName(String fileName) {
-        int len = fileName.length();
-        String parFileName;
-        int extLen = 0;
-        if (fileName.endsWith(".nv")) {
-            extLen = 3;
-        } else if (fileName.endsWith(".ucsf")) {
-            extLen = 5;
-        } else if (fileName.endsWith(".nvlnk")) {
-            extLen = 6;
-        }
-        parFileName = fileName.substring(0, len - extLen) + ".par";
-        return parFileName;
+        Pattern pattern = Pattern.compile("(.+)\\.(nv|ucsf|nvlnk)$");
+        Matcher matcher = pattern.matcher(fileName);
+        int extLen = matcher.find() ? matcher.start() : 0;
+        return fileName.substring(0, fileName.length() - extLen) + ".par";
     }
 
     public final boolean remove() {

--- a/nmrfx-core/src/main/java/org/nmrfx/project/ProjectBase.java
+++ b/nmrfx-core/src/main/java/org/nmrfx/project/ProjectBase.java
@@ -447,7 +447,7 @@ public class ProjectBase {
     }
 
     public void loadDatasets(Path directory) throws IOException {
-        Pattern pattern = Pattern.compile(".(nv|ucsf|nvlnk)$");
+        Pattern pattern = Pattern.compile("\\.(nv|ucsf|nvlnk)$");
         Predicate<String> predicate = pattern.asPredicate();
         if (Files.isDirectory(directory)) {
             try (Stream<Path> files = Files.list(directory)) {

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/Dataset.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/Dataset.java
@@ -30,6 +30,8 @@ import org.nmrfx.peaks.PeakList;
 import org.nmrfx.processor.datasets.vendor.bruker.BrukerData;
 import org.nmrfx.processor.datasets.vendor.NMRData;
 import org.nmrfx.processor.datasets.vendor.NMRDataUtil;
+import org.nmrfx.processor.datasets.vendor.jcamp.JCAMPData;
+import org.nmrfx.processor.datasets.vendor.rs2d.RS2DData;
 import org.nmrfx.processor.math.Matrix;
 import org.nmrfx.processor.math.MatrixND;
 import org.nmrfx.processor.math.Vec;
@@ -499,15 +501,29 @@ public class Dataset extends DatasetBase implements Comparable<Dataset> {
         return dataset;
     }
 
-    public static Dataset newLinkDataset(String name, String fullName) throws IOException {
+    /**
+     * Create a new dataset file from the provided path by first loading as an NMRData and then converting to a dataset.
+     * @param name The name of the new dataset.
+     * @param fullName The name of the file containing the path to the dataset file.
+     * @return A new dataset or null if no NMRData type was found.
+     * @throws IOException if an IO exception occurs.
+     * @throws DatasetException if there is a problem creating the JCAMP dataset.
+     */
+    public static Dataset newLinkDataset(String name, String fullName) throws IOException, DatasetException {
         File linkFile = new File(fullName);
         log.info(fullName);
         String fileString = Files.readString(linkFile.toPath());
         log.info(fileString);
         NMRData nmrData = NMRDataUtil.getNMRData(fileString);
         log.info("{}", nmrData);
-        BrukerData brukerData = (BrukerData) nmrData;
-        return brukerData.toDataset(name);
+        if (nmrData instanceof BrukerData brukerData) {
+            return brukerData.toDataset(name);
+        } else if (nmrData instanceof RS2DData rs2DData) {
+            return rs2DData.toDataset(name);
+        } else if (nmrData instanceof JCAMPData jcampData) {
+            return jcampData.toDataset(name);
+        }
+        return null;
     }
 
     /**

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/Dataset.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/Dataset.java
@@ -303,7 +303,6 @@ public class Dataset extends DatasetBase implements Comparable<Dataset> {
 
             layout = DatasetLayout.createFullMatrix(0, dimSizes);
             this.title = title;
-            this.fileName = title;
             newHeader();
             dataFile = new MemoryFile(this, layout, true);
             dataFile.zero();

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/Dataset.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/Dataset.java
@@ -290,19 +290,24 @@ public class Dataset extends DatasetBase implements Comparable<Dataset> {
      * written to disk so can't be persisted.
      *
      * @param title Dataset title
+     * @param file The file associated with the dataset, if null, the title will be used as the fileName
      * @param dimSizes Sizes of the dataset dimensions
      * @param addFile Whether to add the dataset to the active projects
      * @throws DatasetException if an I/O error occurs
      */
-    public Dataset(String title, int[] dimSizes, boolean addFile) throws DatasetException {
+    public Dataset(String title, File file, int[] dimSizes, boolean addFile) throws DatasetException {
         try {
             this.nDim = dimSizes.length;
 
-            int i;
             setNDim(nDim);
 
             layout = DatasetLayout.createFullMatrix(0, dimSizes);
             this.title = title;
+            if (file != null) {
+                setFile(file);
+            } else {
+                this.fileName = title;
+            }
             newHeader();
             dataFile = new MemoryFile(this, layout, true);
             dataFile.zero();
@@ -311,7 +316,7 @@ public class Dataset extends DatasetBase implements Comparable<Dataset> {
             throw new DatasetException("Can't create dataset " + ioe.getMessage());
         }
         if (addFile) {
-            addFile(title);
+            addFile(this.fileName);
         }
     }
 

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/jcamp/JCAMPData.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/jcamp/JCAMPData.java
@@ -888,8 +888,7 @@ public class JCAMPData implements NMRData {
             datasetName = suggestName(fpath.toFile());
         }
         // Create a dataset in memory
-        Dataset dataset = new Dataset(datasetName, dimSizes, true);
-        dataset.setFile(file);
+        Dataset dataset = new Dataset(datasetName, file, dimSizes, true);
         dataset.newHeader();
         // Set the processed data into the dataset
         boolean hasImaginaryData = this.imaginary.length != 0;

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/jcamp/JCAMPData.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/jcamp/JCAMPData.java
@@ -888,7 +888,8 @@ public class JCAMPData implements NMRData {
             datasetName = suggestName(fpath.toFile());
         }
         // Create a dataset in memory
-        Dataset dataset = new Dataset(datasetName + ".nv", dimSizes, true);
+        Dataset dataset = new Dataset(datasetName, dimSizes, true);
+        dataset.setFile(file);
         dataset.newHeader();
         // Set the processed data into the dataset
         boolean hasImaginaryData = this.imaginary.length != 0;

--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,6 @@
             <id>nanalysis-public</id>
             <url>https://raw.githubusercontent.com/nanalysis/maven-repository/public/</url>
         </repository>
-        <repository>
-            <id>maven-restlet</id>
-            <name>Public online Restlet repository</name>
-            <url>https://maven.restlet.talend.com</url>
-        </repository>
     </repositories>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
             <id>nanalysis-public</id>
             <url>https://raw.githubusercontent.com/nanalysis/maven-repository/public/</url>
         </repository>
+        <repository>
+            <id>maven-restlet</id>
+            <name>Public online Restlet repository</name>
+            <url>https://maven.restlet.talend.com</url>
+        </repository>
     </repositories>
 
     <build>


### PR DESCRIPTION
Spinlab datasets were saving as nvlnk files but weren't loading since only Bruker nvlnk files were set up.
JCAMP datasets were not saving since they didn't have a file set.

Also loaded the regions for the nvlnk files which were ignored previously, no way to store the norm with the nvlnk so I recalculated it


Note: based pr off https://github.com/nanalysis/nmrfx/pull/184 so that I can used the same norm calculations when loading the integrals.