### PR TITLE
Nmr 5730 rs2 d jcamp datasets cant drag and drop

### DIFF
--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/events/FilesDataFormatHandler.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/events/FilesDataFormatHandler.java
@@ -57,18 +57,22 @@ public class FilesDataFormatHandler implements DataFormatEventHandler {
 
     /**
      * Checks if first file in list is dataset is FID or processed. If it is an FID, the first file is opened, if
-     * it is processed, all the files are opened in  append mode.
+     * it is processed, all the files are opened in dataset append mode.
      * @param files The files to open.
      * @param chart The chart to display the files in.
      */
     private void openDataFiles(List<File> files, PolyChart chart) {
         chart.setActiveChart();
-        boolean isFID;
+        boolean isFID = false;
         try {
             isFID = NMRDataUtil.getFID(files.get(0).getAbsolutePath()).isFID();
         } catch (IOException e) {
-            log.warn("Unable to open datafiles. {}", e.getMessage(), e);
-            return;
+            // If the file can't be opened as an FID NMRData, check if it is a datafile, since processed Bruker files
+            // will not open with NMRDataUtil.getFID, otherwise return
+            if (NMRDataUtil.isDatasetFile(files.get(0).getAbsolutePath()) == null) {
+                log.warn("Unable to open datafiles. {}", e.getMessage(), e);
+                return;
+            }
         }
         if (isFID) {
             chart.getController().openFile(files.get(0).getAbsolutePath(), true, false);

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/NMRDataUtil.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/NMRDataUtil.java
@@ -177,6 +177,8 @@ public final class NMRDataUtil {
             return bpath.toString();
         } else if (VarianData.findFID(bpath)) {
             return bpath.toString();
+        } else if (RS2DData.findFID(bpath)) {
+            return bpath.toString();
         } else if (JCAMPData.findFID(bpath)) {
             return bpath.toString();
         } else {
@@ -193,7 +195,8 @@ public final class NMRDataUtil {
      */
     public static String isDatasetFile(String fpath) {
         StringBuilder bpath = new StringBuilder(fpath);
-        if (NMRViewData.findFID(bpath)) {
+        if (NMRViewData.findFID(bpath) || RS2DData.findFID(bpath) || BrukerData.findData(bpath)
+                || VarianData.findFID(bpath) || JCAMPData.findData(bpath)) {
             return bpath.toString();
         } else {
             return null;

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/NMRDataUtil.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/NMRDataUtil.java
@@ -181,6 +181,8 @@ public final class NMRDataUtil {
             return bpath.toString();
         } else if (JCAMPData.findFID(bpath)) {
             return bpath.toString();
+        } else if (JeolDelta.findFID(bpath)) {
+            return bpath.toString();
         } else {
             return null;
         }


### PR DESCRIPTION
JCAMP processed data, RS2D unprocessed and processed data, Bruker processed data and Jeol jdf files (only tested with the two from the test files) can now be drag and dropped 