### PR TITLE
Nmr 5803 improve 1 d projection display

### DIFF
--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/DatasetBrowserController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/DatasetBrowserController.java
@@ -462,7 +462,7 @@ public class DatasetBrowserController implements Initializable {
                 if (!useFID && !rData.getProcessed().isEmpty()) {
                     File localDataset = fileSystem.getPath(getLocalDir().toString(), fileName, rData.getProcessed()).toFile();
                     if (localDataset.exists()) {
-                        controller.openDataset(localDataset, false);
+                        controller.openDataset(localDataset, false, true);
                     }
                 } else {
                     if (!rData.isPresent()) {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/events/PlainTextDataFormatHandler.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/events/PlainTextDataFormatHandler.java
@@ -10,6 +10,11 @@ import org.nmrfx.processor.gui.events.DataFormatEventHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
  * Class to handle clipboard PLAIN_TEXT DataFormat
  */
@@ -70,13 +75,22 @@ public class PlainTextDataFormatHandler implements DataFormatEventHandler {
             if (dataset != null) {
                 Platform.runLater(() -> {
                     chart.setActiveChart();
-                    for (String item : items) {
-                        Dataset dataset1 = Dataset.getDataset(item);
-                        if (dataset1 != null) {
-                            chart.getController().addDataset(dataset1, true, false);
+                    Set<Integer> dimensions = chart.getDatasetAttributes().stream().map(attr ->(Dataset) attr.getDataset()).map(Dataset::getNDim).collect(Collectors.toSet());
+                    List<Dataset> datasetsToAdd = Arrays.stream(items).map(Dataset::getDataset).toList();
+                    datasetsToAdd.forEach(d -> dimensions.add(d.getNDim()));
+                    if (dimensions.size() == 1) {
+                        for (Dataset datasetToAdd: datasetsToAdd) {
+                            chart.getController().addDataset(datasetToAdd, true, false);
                         }
+                    } else {
+                        List<String> datasetNames = chart.getDatasetAttributes().stream().map(attr ->(Dataset) attr.getDataset()).map(Dataset::getName).collect(Collectors.toList());
+                        datasetNames.addAll(Arrays.asList(items));
+                        chart.updateDatasets(datasetNames);
+                        chart.updateProjections();
+                        chart.updateProjectionBorders();
                     }
-
+                    chart.updateProjectionScale();
+                    chart.refresh();
                 });
             return true;
             }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/ScanTable.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/ScanTable.java
@@ -212,7 +212,7 @@ public class ScanTable {
                 if ((dataset == null) || (chart.getDatasetAttributes().size() != 1) || !dataset.getName().equals(datasetName)) {
                     dataset = Dataset.getDataset(datasetName);
                     if (dataset == null) {
-                        FXMLController.getActiveController().openDataset(datasetFile, false);
+                        FXMLController.getActiveController().openDataset(datasetFile, false, true);
                     }
                 }
                 if (!datasetNames.contains(datasetName)) {
@@ -425,7 +425,7 @@ public class ScanTable {
                     }
 
                     // load merged dataset
-                    FXMLController.getActiveController().openDataset(mergedFile, false);
+                    FXMLController.getActiveController().openDataset(mergedFile, false, true);
                     List<Integer> rows = new ArrayList<>();
                     rows.add(0);
                     chart.setDrawlist(rows);
@@ -436,7 +436,7 @@ public class ScanTable {
             } else {
                 // load first output dataset
                 File datasetFile = new File(scanOutputDir, fileRoot + 1 + ".nv");
-                FXMLController.getActiveController().openDataset(datasetFile, false);
+                FXMLController.getActiveController().openDataset(datasetFile, false, true);
             }
             chart.full();
             chart.autoScale();
@@ -561,7 +561,7 @@ public class ScanTable {
         updateDataFrame();
         String firstDatasetName = dataset.getFileName();
         if (firstDatasetName.length() > 0) {
-            FXMLController.getActiveController().openDataset(dataset.getFile(), false);
+            FXMLController.getActiveController().openDataset(dataset.getFile(), false, true);
             List<Integer> rows = new ArrayList<>();
             rows.add(0);
             chart.setDrawlist(rows);
@@ -712,7 +712,7 @@ public class ScanTable {
             if (firstDatasetName.length() > 0) {
                 File parentDir = file.getParentFile();
                 Path path = FileSystems.getDefault().getPath(parentDir.toString(), firstDatasetName);
-                FXMLController.getActiveController().openDataset(path.toFile(), false);
+                FXMLController.getActiveController().openDataset(path.toFile(), false, true);
                 PolyChart chart = scannerTool.getChart();
                 List<Integer> rows = new ArrayList<>();
                 rows.add(0);

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ChartProperties.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ChartProperties.java
@@ -37,6 +37,7 @@ import java.util.Map;
 public class ChartProperties {
     private static final Logger log = LoggerFactory.getLogger(ChartProperties.class);
     public static final int PROJECTION_BORDER_DEFAULT_SIZE = 150;
+    public static final int EMPTY_BORDER_DEFAULT_SIZE = 7;
 
     final private PolyChart polyChart;
 
@@ -115,7 +116,7 @@ public class ChartProperties {
 
     public IntegerProperty rightBorderSizeProperty() {
         if (rightBorderSize == null) {
-            rightBorderSize = new SimpleIntegerProperty(polyChart, "rightBorderSize", 7);
+            rightBorderSize = new SimpleIntegerProperty(polyChart, "rightBorderSize", EMPTY_BORDER_DEFAULT_SIZE);
         }
         return rightBorderSize;
     }
@@ -130,7 +131,7 @@ public class ChartProperties {
 
     public IntegerProperty topBorderSizeProperty() {
         if (topBorderSize == null) {
-            topBorderSize = new SimpleIntegerProperty(polyChart, "topBorderSize", 7);
+            topBorderSize = new SimpleIntegerProperty(polyChart, "topBorderSize", EMPTY_BORDER_DEFAULT_SIZE);
         }
         return topBorderSize;
     }

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ChartProperties.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ChartProperties.java
@@ -36,6 +36,7 @@ import java.util.Map;
  */
 public class ChartProperties {
     private static final Logger log = LoggerFactory.getLogger(ChartProperties.class);
+    public static final int PROJECTION_BORDER_DEFAULT_SIZE = 150;
 
     final private PolyChart polyChart;
 

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ChartProperties.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ChartProperties.java
@@ -37,7 +37,7 @@ import java.util.Map;
 public class ChartProperties {
     private static final Logger log = LoggerFactory.getLogger(ChartProperties.class);
     public static final int PROJECTION_BORDER_DEFAULT_SIZE = 150;
-    public static final int EMPTY_BORDER_DEFAULT_SIZE = 7;
+    public static final int EMPTY_BORDER_DEFAULT_SIZE = 5;
 
     final private PolyChart polyChart;
 

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -670,6 +670,7 @@ public class FXMLController implements  Initializable, PeakNavigable {
                 generateScriptAndParse(nmrData, processorController);
             }
             getActiveChart().clearAnnotations();
+            getActiveChart().removeProjections();
             getActiveChart().layoutPlotChildren();
             statusBar.setMode(0);
         } else {
@@ -716,6 +717,7 @@ public class FXMLController implements  Initializable, PeakNavigable {
         getActiveChart().setCrossHairState(true, true, true, true);
         getActiveChart().clearAnnotations();
         getActiveChart().clearPopoverTools();
+        getActiveChart().removeProjections();
         ProcessorController processorController = getActiveChart().processorController;
         if (processorController != null) {
             processorController.viewingDataset(true);

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -477,46 +477,47 @@ public class FXMLController implements  Initializable, PeakNavigable {
      * @return The newly opened dataset or null if no dataset was opened
      */
     public Dataset openDataset(File selectedFile, boolean append, boolean addDatasetToChart) {
+        if (selectedFile == null) {
+            return null;
+        }
         Dataset dataset = null;
-        if (selectedFile != null) {
-            try {
-                setInitialDirectory(selectedFile.getParentFile());
-                NMRData nmrData = NMRDataUtil.getNMRData(selectedFile.toString());
-                if (!verifyData(nmrData, false, "Use \"Open FID\" to open an fid file")) {
-                    return dataset;
-                }
-                ProcessorController processorController = getActiveChart().getProcessorController(false);
-                if (processorController != null && (!selectedFile.equals(chartProcessor.datasetFile))) {
-                    processorPane.getChildren().clear();
-                    getActiveChart().processorController = null;
-                    processorController.cleanUp();
-                }
-                if (nmrData instanceof NMRViewData nvData) {
-                    PreferencesController.saveRecentDatasets(selectedFile.toString());
-                    dataset = nvData.getDataset();
-                } else if (nmrData instanceof BrukerData brukerData) {
-                    PreferencesController.saveRecentDatasets(selectedFile.toString());
-                    String suggestedName = brukerData.suggestName(new File(brukerData.getFilePath()));
-                    String datasetName = GUIUtils.input("Dataset name", suggestedName);
-                    dataset = brukerData.toDataset(datasetName);
-                } else if (nmrData instanceof  RS2DData rs2dData) {
-                    PreferencesController.saveRecentDatasets(selectedFile.toString());
-                    String suggestedName = rs2dData.suggestName(new File(rs2dData.getFilePath()));
-                    dataset = rs2dData.toDataset(suggestedName);
-                } else if (nmrData instanceof JCAMPData jcampData) {
-                    PreferencesController.saveRecentDatasets(selectedFile.toString());
-                    String suggestedName = jcampData.suggestName(new File (jcampData.getFilePath()));
-                    dataset = jcampData.toDataset(suggestedName);
-                }
-            } catch (IOException | DatasetException ex) {
-                log.warn(ex.getMessage(), ex);
-                GUIUtils.warn("Open Dataset", ex.getMessage());
+        try {
+            setInitialDirectory(selectedFile.getParentFile());
+            NMRData nmrData = NMRDataUtil.getNMRData(selectedFile.toString());
+            if (!verifyData(nmrData, false, "Use \"Open FID\" to open an fid file")) {
+                return null;
             }
-            if (dataset != null && addDatasetToChart) {
-                addDataset(dataset, append, false);
-            } else if (dataset == null) {
-                log.info("Unable to find a dataset format for: {}", selectedFile);
+            ProcessorController processorController = getActiveChart().getProcessorController(false);
+            if (processorController != null && (!selectedFile.equals(chartProcessor.datasetFile))) {
+                processorPane.getChildren().clear();
+                getActiveChart().processorController = null;
+                processorController.cleanUp();
             }
+            if (nmrData instanceof NMRViewData nvData) {
+                PreferencesController.saveRecentDatasets(selectedFile.toString());
+                dataset = nvData.getDataset();
+            } else if (nmrData instanceof BrukerData brukerData) {
+                PreferencesController.saveRecentDatasets(selectedFile.toString());
+                String suggestedName = brukerData.suggestName(new File(brukerData.getFilePath()));
+                String datasetName = GUIUtils.input("Dataset name", suggestedName);
+                dataset = brukerData.toDataset(datasetName);
+            } else if (nmrData instanceof  RS2DData rs2dData) {
+                PreferencesController.saveRecentDatasets(selectedFile.toString());
+                String suggestedName = rs2dData.suggestName(new File(rs2dData.getFilePath()));
+                dataset = rs2dData.toDataset(suggestedName);
+            } else if (nmrData instanceof JCAMPData jcampData) {
+                PreferencesController.saveRecentDatasets(selectedFile.toString());
+                String suggestedName = jcampData.suggestName(new File (jcampData.getFilePath()));
+                dataset = jcampData.toDataset(suggestedName);
+            }
+        } catch (IOException | DatasetException ex) {
+            log.warn(ex.getMessage(), ex);
+            GUIUtils.warn("Open Dataset", ex.getMessage());
+        }
+        if (dataset != null && addDatasetToChart) {
+            addDataset(dataset, append, false);
+        } else if (dataset == null) {
+            log.info("Unable to find a dataset format for: {}", selectedFile);
         }
         stage.setResizable(true);
         return dataset;

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -4474,4 +4474,15 @@ public class PolyChart extends Region implements PeakListener {
             sliceAttributes.setScaleValue(actualScale * initialDatasetAttr.get().getLvl());
         }
     }
+
+    /**
+     * Remove all datasetAttributes that are projections, reset the chart borders back to the empty default
+     * and refresh the chart.
+     */
+    public void removeProjections() {
+        getDatasetAttributes().removeIf(datasetAttributes -> datasetAttributes.projection() != -1);
+        chartProps.setTopBorderSize(ChartProperties.EMPTY_BORDER_DEFAULT_SIZE);
+        chartProps.setRightBorderSize(ChartProperties.EMPTY_BORDER_DEFAULT_SIZE);
+        refresh();
+    }
 }

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -1613,7 +1613,7 @@ public class PolyChart extends Region implements PeakListener {
             int jData = 0;
             int addAt = -1;
             for (DatasetAttributes datasetAttr : datasetAttrs) {
-                if (datasetAttr.getDataset().getName().equals(s)) {
+                if (datasetAttr.getDataset().getName().equals(s) && !newList.contains(datasetAttr)) {
                     newList.add(datasetAttr);
                     addAt = jData;
                 }
@@ -1675,6 +1675,7 @@ public class PolyChart extends Region implements PeakListener {
             }
         }
         boolean mixedDim = has1D && hasND;
+        List<Integer> alreadyMatchedDims = new ArrayList<>();
         for (DatasetAttributes datasetAttributes : datasetAttributesList) {
             Dataset dataset = (Dataset) datasetAttributes.getDataset();
             if (!mixedDim || (dataset == null) || dataset.getNDim() > 1) {
@@ -1682,7 +1683,13 @@ public class PolyChart extends Region implements PeakListener {
             } else {
                 int[] matchDim = datasetAttributes.getMatchDim(firstNDAttr.get(), true);
                 if (matchDim[0] != -1) {
-                    datasetAttributes.projection(matchDim[0]);
+                    if (!alreadyMatchedDims.contains(matchDim[0])) {
+                        datasetAttributes.projection(matchDim[0]);
+                        alreadyMatchedDims.add(matchDim[0]);
+                    } else {
+                        // If the projection is already set for the other axis of a homonuclear experiment, switch the axis
+                        datasetAttributes.projection(matchDim[0] == 0 ? 1 : 0);
+                    }
                 }
             }
         }

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -4467,8 +4467,7 @@ public class PolyChart extends Region implements PeakListener {
                     }
                 }
             } catch (IOException e) {
-                throw new RuntimeException(e);
-
+                log.warn("Unable to update projection scale. {}",e.getMessage(), e);
             }
             Double actualScale = scaleValues.stream().min(Comparator.naturalOrder()).orElse(0.0);
             sliceAttributes.setScaleValue(actualScale * initialDatasetAttr.get().getLvl());

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PreferencesController.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PreferencesController.java
@@ -316,7 +316,7 @@ public class PreferencesController implements Initializable {
             // special check to put existing (from previous version of code)
             // FID files  in FID menu
             MenuItem datasetMenuItem = new MenuItem(subPath.toString());
-            datasetMenuItem.setOnAction(e -> FXMLController.getActiveController().openDataset(path.toFile(), false));
+            datasetMenuItem.setOnAction(e -> FXMLController.getActiveController().openDataset(path.toFile(), false, true));
             recentDatasetMenuItem.getItems().add(datasetMenuItem);
 
         }

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ProcessorController.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ProcessorController.java
@@ -430,7 +430,7 @@ public class ProcessorController implements Initializable, ProgressUpdater {
         } else {
             if (chartProcessor.datasetFile != null) {
                 boolean viewingDataset = isViewingDataset();
-                chart.controller.openDataset(chartProcessor.datasetFile, false);
+                chart.controller.openDataset(chartProcessor.datasetFile, false, true);
                 viewMode.getSelectionModel().select(1);
                 if (!viewingDataset) {
                     chart.full();

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/SpecAttrWindowController.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/SpecAttrWindowController.java
@@ -1365,6 +1365,13 @@ public class SpecAttrWindowController implements Initializable {
     private void updateChartDatasets() {
         ObservableList<String> datasetTargets = datasetView.getTargetItems();
         chart.updateDatasets(datasetTargets);
+        if (datasetTargets.isEmpty()) {
+            chart.removeProjections();
+        } else {
+            chart.updateProjections();
+            chart.updateProjectionBorders();
+            chart.updateProjectionScale();
+        }
     }
 
     @FXML

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/SpecAttrWindowController.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/SpecAttrWindowController.java
@@ -1367,6 +1367,7 @@ public class SpecAttrWindowController implements Initializable {
         chart.updateDatasets(datasetTargets);
         if (datasetTargets.isEmpty()) {
             chart.removeProjections();
+            chart.getCrossHairs().hideCrossHairs();
         } else {
             chart.updateProjections();
             chart.updateProjectionBorders();

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/SpectrumMenu.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/SpectrumMenu.java
@@ -179,6 +179,8 @@ public class SpectrumMenu extends ChartMenu {
         projectMenuItem.setOnAction((ActionEvent e) -> {
             chart.projectDataset();
         });
+        MenuItem removeProjectionsItem = new MenuItem("Remove Projections");
+        removeProjectionsItem.setOnAction((ActionEvent e) -> chart.removeProjections());
         MenuItem extractXMenuItem = new MenuItem("Extract-X");
         extractXMenuItem.setOnAction((ActionEvent e) -> {
             chart.extractSlice(0);
@@ -191,7 +193,7 @@ public class SpectrumMenu extends ChartMenu {
         extractZMenuItem.setOnAction((ActionEvent e) -> {
             chart.extractSlice(2);
         });
-        extractMenu.getItems().addAll(projectMenuItem, extractXMenuItem, extractYMenuItem, extractZMenuItem);
+        extractMenu.getItems().addAll(projectMenuItem, removeProjectionsItem, extractXMenuItem, extractYMenuItem, extractZMenuItem);
 
         Menu linkMenu = new Menu("Peak Linking");
         MenuItem linkColumnMenuItem = new MenuItem("Link Selected Column");


### PR DESCRIPTION
Dragging 1D dataset onto 2D dataset will resize the border and add as a projection to the matching axis.
Projections can be removed through the Extract Slice/ Projection menu.
Projections can be scaled using Attributes -> Slices -> Scale slider which will scale both projections together

Scaling still needs to be improved; changes made in: https://github.com/nanalysis/nmrfx/pull/196

This pr does not cover the case of what should happen if a user drags a 2D dataset onto a 1D dataset (Jira issue made: NMR-5731)
