### PR TITLE
NMR-5803 projections with JCAMP RS2D datasets

### DIFF
--- a/nmrfx-core/src/main/java/org/nmrfx/datasets/DatasetBase.java
+++ b/nmrfx-core/src/main/java/org/nmrfx/datasets/DatasetBase.java
@@ -15,11 +15,11 @@ import java.util.*;
 public class DatasetBase {
     private static final Logger log = LoggerFactory.getLogger(DatasetBase.class);
 
-    public final static int NV_HEADER_SIZE = 2048;
-    public final static int UCSF_HEADER_SIZE = 180;
-    public final static int LABEL_MAX_BYTES = 16;
-    public final static int SOLVENT_MAX_BYTES = 24;
-    public final static String DATASET_PROJECTION_TAG = "_proj_";
+    public static final int NV_HEADER_SIZE = 2048;
+    public static final int UCSF_HEADER_SIZE = 180;
+    public static final int LABEL_MAX_BYTES = 16;
+    public static final int SOLVENT_MAX_BYTES = 24;
+    public static final String DATASET_PROJECTION_TAG = "_proj_";
     public DatasetLayout layout = null;
     /**
      *

--- a/nmrfx-core/src/main/java/org/nmrfx/datasets/DatasetBase.java
+++ b/nmrfx-core/src/main/java/org/nmrfx/datasets/DatasetBase.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.ByteOrder;
 import java.util.*;
 
@@ -18,6 +19,7 @@ public class DatasetBase {
     public final static int UCSF_HEADER_SIZE = 180;
     public final static int LABEL_MAX_BYTES = 16;
     public final static int SOLVENT_MAX_BYTES = 24;
+    public final static String DATASET_PROJECTION_TAG = "_proj_";
     public DatasetLayout layout = null;
     /**
      *
@@ -775,6 +777,26 @@ public class DatasetBase {
         if (file != null) {
             DatasetParameterFile parFile = new DatasetParameterFile(this, layout);
             parFile.writeFile();
+        }
+    }
+
+    /**
+     * Write the data values to a file. Only works if the dataset values are in
+     * a Vec object (not dataset file)
+     *
+     * @param newFile New file to write to
+     * @throws java.io.IOException if an I/O error ocurrs
+     */
+    public void writeVecMat(File newFile) throws IOException {
+        if (vecMat == null) {
+            log.info("Vector Matrix is null. Unable to write file");
+            return;
+        }
+        try (RandomAccessFile outFile = new RandomAccessFile(newFile, "rw")) {
+            byte[] buffer = vecMat.getBytes();
+            DatasetHeaderIO headerIO = new DatasetHeaderIO(this);
+            headerIO.writeHeader(layout, outFile);
+            DataUtilities.writeBytes(outFile, buffer, layout.getFileHeaderSize(), buffer.length);
         }
     }
 

--- a/nmrfx-core/src/main/java/org/nmrfx/math/VecBase.java
+++ b/nmrfx-core/src/main/java/org/nmrfx/math/VecBase.java
@@ -131,7 +131,7 @@ public class VecBase extends PySequence implements MatrixType, DatasetStorageInt
     public VecBase(int size, boolean complex, PyType type) {
         super(type);
         this.isComplex = complex;
-        useApache = true;
+        useApache = complex;
         rvec = new double[size];
         freqDomain = false;
 

--- a/nmrfx-core/src/main/java/org/nmrfx/math/VecBase.java
+++ b/nmrfx-core/src/main/java/org/nmrfx/math/VecBase.java
@@ -131,7 +131,7 @@ public class VecBase extends PySequence implements MatrixType, DatasetStorageInt
     public VecBase(int size, boolean complex, PyType type) {
         super(type);
         this.isComplex = complex;
-        useApache = complex;
+        useApache = true;
         rvec = new double[size];
         freqDomain = false;
 
@@ -1036,7 +1036,7 @@ public class VecBase extends PySequence implements MatrixType, DatasetStorageInt
                     buffer[j++] = (byte) (intVal & 0xFF);
                 }
             }
-        } else if (useApache) {
+        } else if (useApache && cvec != null) {
             for (int i = 0; i < size; i++) {
                 int intVal = Float.floatToIntBits((float) cvec[i].getReal());
                 buffer[j++] = (byte) ((intVal >> 24) & 0xFF);

--- a/nmrfx-core/src/main/java/org/nmrfx/math/VecBase.java
+++ b/nmrfx-core/src/main/java/org/nmrfx/math/VecBase.java
@@ -1036,14 +1036,6 @@ public class VecBase extends PySequence implements MatrixType, DatasetStorageInt
                     buffer[j++] = (byte) (intVal & 0xFF);
                 }
             }
-        } else if (useApache && cvec != null) {
-            for (int i = 0; i < size; i++) {
-                int intVal = Float.floatToIntBits((float) cvec[i].getReal());
-                buffer[j++] = (byte) ((intVal >> 24) & 0xFF);
-                buffer[j++] = (byte) ((intVal >> 16) & 0xFF);
-                buffer[j++] = (byte) ((intVal >> 8) & 0xFF);
-                buffer[j++] = (byte) (intVal & 0xFF);
-            }
         } else {
             for (int i = 0; i < size; i++) {
                 int intVal = Float.floatToIntBits((float) rvec[i]);

--- a/nmrfx-core/src/main/java/org/nmrfx/project/ProjectBase.java
+++ b/nmrfx-core/src/main/java/org/nmrfx/project/ProjectBase.java
@@ -507,32 +507,38 @@ public class ProjectBase {
 
         for (DatasetBase datasetBase : datasetMap.values()) {
             File datasetFile = datasetBase.getFile();
-            if (datasetFile != null) {
-                Path currentPath = datasetFile.toPath();
-                Path fileNameAsPath = currentPath.getFileName();
-                String fileName = fileNameAsPath.toString();
-                Path pathInProject;
-
-                if (fileName.endsWith(".nv") || fileName.endsWith(".ucsf")) {
-                    pathInProject = datasetDir.resolve(fileNameAsPath);
-                    if (!Files.exists(pathInProject)) {
-                        try {
-                            Files.createLink(pathInProject, currentPath);
-                        } catch (IOException | UnsupportedOperationException | SecurityException ex) {
-                            Files.createSymbolicLink(pathInProject, currentPath);
-                        }
-                    }
-                } else {
-                    String fileLinkName = datasetBase.getName() + ".nvlnk";
-                    pathInProject = datasetDir.resolve(fileLinkName);
-                    Files.writeString(pathInProject, datasetFile.getAbsolutePath());
+            if (datasetFile == null) {
+                // Save any extracted projection datasets that are vec matrix based
+                if (datasetBase.getFileName().contains(DatasetBase.DATASET_PROJECTION_TAG) && datasetBase.getVec() != null) {
+                    File newFile = new File(datasetDir.toFile(), datasetBase.getName());
+                    datasetBase.writeVecMat(newFile);
                 }
-                String parFilePath = DatasetParameterFile.getParameterFileName(pathInProject.toString());
-                datasetBase.writeParFile(parFilePath);
-                TreeSet<DatasetRegion> regions = datasetBase.getRegions();
-                File regionFile = DatasetRegion.getRegionFile(pathInProject.toString());
-                DatasetRegion.saveRegions(regionFile, regions);
+                continue;
             }
+            Path currentPath = datasetFile.toPath();
+            Path fileNameAsPath = currentPath.getFileName();
+            String fileName = fileNameAsPath.toString();
+            Path pathInProject;
+
+            if (fileName.endsWith(".nv") || fileName.endsWith(".ucsf")) {
+                pathInProject = datasetDir.resolve(fileNameAsPath);
+                if (!Files.exists(pathInProject)) {
+                    try {
+                        Files.createLink(pathInProject, currentPath);
+                    } catch (IOException | UnsupportedOperationException | SecurityException ex) {
+                        Files.createSymbolicLink(pathInProject, currentPath);
+                    }
+                }
+            } else {
+                String fileLinkName = datasetBase.getName() + ".nvlnk";
+                pathInProject = datasetDir.resolve(fileLinkName);
+                Files.writeString(pathInProject, datasetFile.getAbsolutePath());
+            }
+            String parFilePath = DatasetParameterFile.getParameterFileName(pathInProject.toString());
+            datasetBase.writeParFile(parFilePath);
+            TreeSet<DatasetRegion> regions = datasetBase.getRegions();
+            File regionFile = DatasetRegion.getRegionFile(pathInProject.toString());
+            DatasetRegion.saveRegions(regionFile, regions);
         }
     }
 

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/MainApp.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/MainApp.java
@@ -92,7 +92,7 @@ public class MainApp extends Application {
             chart.clearDataAndPeaks();
             chart.clearAnnotations();
         }
-        List<FXMLController> controllers = FXMLController.getControllers();
+        List<FXMLController> controllers = new ArrayList<>(FXMLController.getControllers());
         // Don't close the first controller that matches with the main stage, Note this first controller is not
         // necessarily the active controller
         for (int index = 1; index < controllers.size(); index++) {

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PeakPicking.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PeakPicking.java
@@ -42,9 +42,7 @@ public class PeakPicking {
         PolyChart chart = fxmlController.getActiveChart();
         ObservableList<DatasetAttributes> dataList = chart.getDatasetAttributes();
         dataList.stream().filter(dataAttr -> !dataAttr.isProjection())
-                .forEach((DatasetAttributes dataAttr) -> {
-                    peakPickActive(chart, dataAttr, chart.getCrossHairs().hasCrosshairRegion(), refineLS, level, false, null);
-                });
+                .forEach((DatasetAttributes dataAttr) -> peakPickActive(chart, dataAttr, chart.getCrossHairs().hasCrosshairRegion(), refineLS, level, false, null));
         chart.refresh();
     }
 

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PeakPicking.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PeakPicking.java
@@ -37,12 +37,14 @@ public class PeakPicking {
     public static void peakPickActive(FXMLController fxmlController, double level) {
         peakPickActive(fxmlController, false, level);
     }
+
     public static void peakPickActive(FXMLController fxmlController, boolean refineLS, Double level) {
         PolyChart chart = fxmlController.getActiveChart();
         ObservableList<DatasetAttributes> dataList = chart.getDatasetAttributes();
-        dataList.stream().forEach((DatasetAttributes dataAttr) -> {
-            peakPickActive(chart, dataAttr, chart.getCrossHairs().hasCrosshairRegion(), refineLS, level, false, null);
-        });
+        dataList.stream().filter(dataAttr -> !dataAttr.isProjection())
+                .forEach((DatasetAttributes dataAttr) -> {
+                    peakPickActive(chart, dataAttr, chart.getCrossHairs().hasCrosshairRegion(), refineLS, level, false, null);
+                });
         chart.refresh();
     }
 

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -316,7 +316,7 @@ public class PolyChart extends Region implements PeakListener {
         return chartSelected.get();
     }
 
-    public ObjectProperty getDisDimProperty() {
+    public ObjectProperty<DISDIM> getDisDimProperty() {
         return disDimProp;
     }
 

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -4482,13 +4482,13 @@ public class PolyChart extends Region implements PeakListener {
     public void updateProjectionScale() {
         Optional<DatasetAttributes> initialDatasetAttr = getFirstDatasetAttributes();
         if (initialDatasetAttr.isPresent()) {
-            Vec projectionVec = new Vec(32, false);
             try {
                 List<Integer> borders = Arrays.asList(chartProps.getTopBorderSize(), chartProps.getRightBorderSize());
                 for (int i = 0; i < borders.size(); i++) {
                     int projectionDim = i;
                     Optional<DatasetAttributes> projectionDimAttr = getDatasetAttributes().stream().filter(attr -> attr.projection() == projectionDim).findFirst();
                     if (projectionDimAttr.isPresent()) {
+                        Vec projectionVec = new Vec(32, projectionDimAttr.get().getDataset().getComplex(0));
                         initialDatasetAttr.get().getProjection((Dataset) projectionDimAttr.get().getDataset(), projectionVec, projectionDim);
                         OptionalDouble maxValue = Arrays.stream(projectionVec.getReal()).max();
                         if (maxValue.isPresent()) {

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -915,9 +915,7 @@ public class PolyChart extends Region implements PeakListener {
     protected void adjustScale(double factor) {
         ChartUndoScale undo = new ChartUndoScale(this);
         datasetAttributesList.stream().filter(dataAttr -> !dataAttr.isProjection())
-                .forEach(dataAttr -> {
-                    adjustScale(dataAttr, factor);
-                });
+                .forEach(dataAttr -> adjustScale(dataAttr, factor));
         layoutPlotChildren();
         ChartUndoScale redo = new ChartUndoScale(this);
         controller.undoManager.add("ascale", undo, redo);
@@ -4523,7 +4521,7 @@ public class PolyChart extends Region implements PeakListener {
      * and refresh the chart.
      */
     public void removeProjections() {
-        if (getDatasetAttributes().removeIf(datasetAttributes -> datasetAttributes.isProjection())) {
+        if (getDatasetAttributes().removeIf(DatasetAttributes::isProjection)) {
             chartProps.setTopBorderSize(ChartProperties.EMPTY_BORDER_DEFAULT_SIZE);
             chartProps.setRightBorderSize(ChartProperties.EMPTY_BORDER_DEFAULT_SIZE);
             refresh();

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -316,6 +316,10 @@ public class PolyChart extends Region implements PeakListener {
         return chartSelected.get();
     }
 
+    public ObjectProperty getDisDimProperty() {
+        return disDimProp;
+    }
+
     public double[][] getCorners() {
         double[][] corners = new double[4][2];
         double xPos = getLayoutX();
@@ -1782,6 +1786,10 @@ public class PolyChart extends Region implements PeakListener {
     public int setDrawlist(int value) {
         if (!datasetAttributesList.isEmpty()) {
             for (DatasetAttributes datasetAttributes : datasetAttributesList) {
+                if (datasetAttributes.projection() != -1 || datasetAttributes.getDataset().getNDim() < 2) {
+                    datasetAttributes.setDrawListSize(0);
+                    continue;
+                }
                 datasetAttributes.setDrawListSize(1);
                 DatasetBase dataset = datasetAttributes.getDataset();
                 if (value < 0) {
@@ -4486,9 +4494,10 @@ public class PolyChart extends Region implements PeakListener {
      * and refresh the chart.
      */
     public void removeProjections() {
-        getDatasetAttributes().removeIf(datasetAttributes -> datasetAttributes.projection() != -1);
-        chartProps.setTopBorderSize(ChartProperties.EMPTY_BORDER_DEFAULT_SIZE);
-        chartProps.setRightBorderSize(ChartProperties.EMPTY_BORDER_DEFAULT_SIZE);
-        refresh();
+        if (getDatasetAttributes().removeIf(datasetAttributes -> datasetAttributes.projection() != -1)) {
+            chartProps.setTopBorderSize(ChartProperties.EMPTY_BORDER_DEFAULT_SIZE);
+            chartProps.setRightBorderSize(ChartProperties.EMPTY_BORDER_DEFAULT_SIZE);
+            refresh();
+        }
     }
 }

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -4467,7 +4467,7 @@ public class PolyChart extends Region implements PeakListener {
                     Optional<DatasetAttributes> projectionDimAttr = getDatasetAttributes().stream().filter(attr -> attr.projection() == projectionDim).findFirst();
                     if (projectionDimAttr.isPresent()) {
                         initialDatasetAttr.get().getProjection((Dataset) projectionDimAttr.get().getDataset(), projectionVec, projectionDim);
-                        OptionalDouble maxValue = Arrays.stream(projectionVec.rvec).max();
+                        OptionalDouble maxValue = Arrays.stream(projectionVec.getReal()).max();
                         if (maxValue.isPresent()) {
                             scaleValues.add((borders.get(i) * 0.95) / maxValue.getAsDouble());
                         }

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/SpectrumStatusBar.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/SpectrumStatusBar.java
@@ -705,6 +705,8 @@ public class SpectrumStatusBar {
 
             } else if (selected == DisplayMode.CONTOURS) {
                 chart.disDimProp.set(PolyChart.DISDIM.TwoD);
+                chart.updateProjections();
+                chart.updateProjectionScale();
                 setMode(maxNDim.getAsInt());
             }
             chart.full();

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/DatasetAttributes.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/DatasetAttributes.java
@@ -927,8 +927,8 @@ public class DatasetAttributes extends DataGenerator implements Cloneable {
         dimC[0] = 0;
         ptC[0][0] = dataset.ppmToPoint(0, ppm0);
         ptC[0][1] = dataset.ppmToPoint(0, ppm1);
-        specVec.resize(ptC[0][1] - ptC[0][0] + 1, dataset.getComplex_r(0));
-        dataset.readVectorFromDatasetFile(DatasetUtils.generateRawIndices(ptC, dataset.getComplex_r(0)), dimC, specVec);
+        specVec.resize(ptC[0][1] - ptC[0][0] + 1, dataset.getComplex(0));
+        dataset.readVectorFromDatasetFile(DatasetUtils.generateRawIndices(ptC, dataset.getComplex(0)), dimC, specVec);
     }
 
     public boolean getSlice(Vec specVec, int iDim, double ppmx, double ppmy) throws IOException {

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/DatasetAttributes.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/DatasetAttributes.java
@@ -575,14 +575,6 @@ public class DatasetAttributes extends DataGenerator implements Cloneable {
         return projectionAxis;
     }
 
-    public void setProjectionScale(double projectionScale) {
-        this.projectionScale = projectionScale;
-    }
-
-    public double getProjectionScale() {
-        return projectionScale;
-    }
-
     private StringProperty fileName;
 
     public StringProperty fileNameProperty() {
@@ -698,7 +690,6 @@ public class DatasetAttributes extends DataGenerator implements Cloneable {
     public boolean selected;
     public boolean intSelected;
     private int projectionAxis = -1;
-    private double projectionScale = 1.0;
     public String title = "";
 
     public DatasetAttributes(DatasetBase aFile, String fileName) {

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/DatasetAttributes.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/DatasetAttributes.java
@@ -928,7 +928,7 @@ public class DatasetAttributes extends DataGenerator implements Cloneable {
         ptC[0][0] = dataset.ppmToPoint(0, ppm0);
         ptC[0][1] = dataset.ppmToPoint(0, ppm1);
         specVec.resize(ptC[0][1] - ptC[0][0] + 1, dataset.getComplex_r(0));
-        dataset.readVectorFromDatasetFile(ptC, dimC, specVec);
+        dataset.readVectorFromDatasetFile(DatasetUtils.generateRawIndices(ptC, dataset.getComplex_r(0)), dimC, specVec);
     }
 
     public boolean getSlice(Vec specVec, int iDim, double ppmx, double ppmy) throws IOException {

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/DatasetAttributes.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/DatasetAttributes.java
@@ -571,6 +571,10 @@ public class DatasetAttributes extends DataGenerator implements Cloneable {
         projectionAxis = value;
     }
 
+    public boolean isProjection() {
+        return projectionAxis != -1;
+    }
+
     public int projection() {
         return projectionAxis;
     }

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/DrawSpectrum.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/DrawSpectrum.java
@@ -807,17 +807,16 @@ public class DrawSpectrum {
         boolean drawReal = datasetAttr.getDrawReal();
         try {
             datasetAttr.getProjection((Dataset) projectionDatasetAttributes.getDataset(), sliceVec, sliceDim);
-            double scale = -projectionDatasetAttributes.getProjectionScale();
+            double lvlMult = projectionDatasetAttributes.getLvl();
             if (sliceDim == 0) {
                 double offset = axes[0].getYOrigin() - axes[1].getHeight() * 1.005;
                 drawVector(sliceVec, orientation, 0, AXMODE.PPM, drawReal, 0.0, 0.0, null,
                         (index, intensity) -> axes[0].getDisplayPosition(index),
-                        (index, intensity) -> intensity * scale + offset, false, false);
+                        (index, intensity) -> -intensity / lvlMult + offset, false, false);
             } else {
                 double offset = axes[0].getXOrigin() + axes[0].getWidth() * 1.005;
-
                 drawVector(sliceVec, orientation, 0, AXMODE.PPM, drawReal, 0.0, 0.0, null,
-                        (index, intensity) -> -intensity * scale + offset,
+                        (index, intensity) -> intensity / lvlMult + offset,
                         (index, intensity) -> axes[1].getDisplayPosition(index), false, false);
             }
         } catch (IOException ioE) {

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/GestureBindings.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/GestureBindings.java
@@ -77,8 +77,7 @@ public class GestureBindings {
         if (event.isControlDown() && border == ChartBorder.NONE) {
             chart.scaleY(dy);
         } else if (border == ChartBorder.RIGHT || border == ChartBorder.TOP) {
-            // Divide by 500 to make it easier to scale, doesn't change as quickly
-            chart.updateProjectionScale(border, -dy / 500);
+            chart.updateProjectionScale(border, dy);
             chart.refresh();
         } else if ((border == ChartBorder.LEFT || border == ChartBorder.BOTTOM) || (event.isAltDown() && border == ChartBorder.NONE)) {
             chart.zoom(-dy / 50.0 + 1.0);

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/SpectrumMenu.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/SpectrumMenu.java
@@ -180,6 +180,7 @@ public class SpectrumMenu extends ChartMenu {
             chart.projectDataset();
         });
         MenuItem removeProjectionsItem = new MenuItem("Remove Projections");
+        removeProjectionsItem.visibleProperty().bind(chart.getDisDimProperty().isEqualTo(PolyChart.DISDIM.TwoD));
         removeProjectionsItem.setOnAction((ActionEvent e) -> chart.removeProjections());
         MenuItem extractXMenuItem = new MenuItem("Extract-X");
         extractXMenuItem.setOnAction((ActionEvent e) -> {

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/mousehandlers/MouseBindings.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/spectra/mousehandlers/MouseBindings.java
@@ -265,13 +265,13 @@ public class MouseBindings {
         hidePopOver(false);
 
         boolean altShift = mouseEvent.isShiftDown() && (mouseEvent.isAltDown() || mouseEvent.isControlDown());
-        ChartBorder border = chart.hitBorder(mouseX, mouseY);
         if (chart.isSelected()) {
             Optional<Integer> hitCorner = hitChartCorner(mouseX, mouseY, 10);
             return;
         }
 
         if (!isPopupTrigger(mouseEvent)) {
+            ChartBorder border = chart.hitBorder(mouseX, mouseY);
             if (!(altShift || (border == ChartBorder.LEFT || border == ChartBorder.BOTTOM)) && (mouseEvent.isMetaDown() || chart.getCanvasCursor().toString().equals("CROSSHAIR"))) {
                 if (!chart.getCanvasCursor().toString().equals("CROSSHAIR")) {
                     chart.getCrossHairs().setCrossHairState(true);

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/Dataset.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/Dataset.java
@@ -2248,7 +2248,10 @@ public class Dataset extends DatasetBase implements Comparable<Dataset> {
             pt[0][1] = getSizeTotal(iDim) - 1;
             origSize = pt[0][1];
             int newSize = pt[0][1] - pt[0][0] + 1;
-            vec = new Vec(newSize, false);
+            if (getComplex(iDim)) {
+                newSize /= 2;
+            }
+            vec = new Vec(newSize, getComplex(iDim));
             scanRegion = new ScanRegion(pt, dim, dataset);
         }
 
@@ -2564,7 +2567,7 @@ public class Dataset extends DatasetBase implements Comparable<Dataset> {
         if (projections == null) {
             projections = new Dataset[getNDim()];
         }
-        Vec projVec = new Vec(getSizeTotal(iDim));
+        Vec projVec = new Vec(getSizeReal(iDim), getComplex(iDim));
         projVec.setName(getName() + DatasetBase.DATASET_PROJECTION_TAG + (iDim + 1) +".nv");
         readVector(projVec, 0, iDim);
         projVec.zeros();
@@ -2573,6 +2576,7 @@ public class Dataset extends DatasetBase implements Comparable<Dataset> {
             Vec vec = iter.next();
             projVec.max(vec);
         }
+        projVec.makeReal();
         Dataset projDataset = new Dataset(projVec);
         projDataset.setRefPt(0, getRefPt(iDim));
         projDataset.setLabel(0, getLabel(iDim));

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/Dataset.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/Dataset.java
@@ -193,6 +193,7 @@ public class Dataset extends DatasetBase implements Comparable<Dataset> {
         title = fileName;
         nDim = 1;
         vsize = new int[1];
+        vsize[0] = vector.getSize();
         vsize_r = new int[1];
         tdSize = new int[1];
         zfSize = new int[1];
@@ -200,7 +201,7 @@ public class Dataset extends DatasetBase implements Comparable<Dataset> {
         extLast = new int[1];
         tdSize[0] = vector.getTDSize();
         fileSize = vector.getSize();
-        layout = DatasetLayout.createFullMatrix(0, vsize);
+        layout = DatasetLayout.createFullMatrix(getFileHeaderSize(title), vsize);
         newHeader();
         memoryMode = false;
 
@@ -1327,22 +1328,7 @@ public class Dataset extends DatasetBase implements Comparable<Dataset> {
         return Math.max(Math.abs(maxValue), Math.abs(minValue));
     }
 
-    /**
-     * Write the data values to a file. Only works if the dataset values are in
-     * a Vec object (not dataset file)
-     *
-     * @param fullName Name of file to write
-     * @throws java.io.IOException if an I/O error ocurrs
-     */
-    public void writeVecMat(String fullName) throws IOException {
-        File newFile = new File(fullName);
-        try (RandomAccessFile outFile = new RandomAccessFile(newFile, "rw")) {
-            byte[] buffer = vecMat.getBytes();
-            DatasetHeaderIO headerIO = new DatasetHeaderIO(this);
-            headerIO.writeHeader(layout, outFile);
-            DataUtilities.writeBytes(outFile, buffer, layout.getFileHeaderSize(), buffer.length);
-        }
-    }
+
 
     /**
      * Write a matrix of values to the dataset
@@ -1574,6 +1560,12 @@ public class Dataset extends DatasetBase implements Comparable<Dataset> {
         }
         if (vecMat != null) {
             int j = 0;
+            // If the vectors are complex, convert the raw indices to real since the complex can be read from the
+            // vecMat in one loop iteration (when reading from the file, it takes 2 loop iterations)
+            if (rwVector.isComplex() && vecMat.isComplex()) {
+                pt[0][0] /= 2;
+                pt[0][1] /= 2;
+            }
             for (int i = pt[0][0]; i <= pt[0][1]; i++) {
                 if (rwVector.isComplex()) {
                     rwVector.set(j, vecMat.getComplex(i));
@@ -2573,7 +2565,7 @@ public class Dataset extends DatasetBase implements Comparable<Dataset> {
             projections = new Dataset[getNDim()];
         }
         Vec projVec = new Vec(getSizeTotal(iDim));
-        projVec.setName(getName() + "_proj_" + (iDim + 1));
+        projVec.setName(getName() + DatasetBase.DATASET_PROJECTION_TAG + (iDim + 1) +".nv");
         readVector(projVec, 0, iDim);
         projVec.zeros();
         Iterator<Vec> iter = vectors(iDim);

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/Dataset.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/Dataset.java
@@ -2574,6 +2574,7 @@ public class Dataset extends DatasetBase implements Comparable<Dataset> {
             projVec.max(vec);
         }
         Dataset projDataset = new Dataset(projVec);
+        projDataset.setRefPt(0, getRefPt(iDim));
         projDataset.setLabel(0, getLabel(iDim));
         projections[iDim] = projDataset;
     }


### PR DESCRIPTION
projections with complex datasets had 2 issues, the empty real vec was being read instead of real values from complex vec, and only half the file was read due to real indices being passed instead of raw to readDatasetFromFile

Also fixed exception that occurs if a user switched from 2D view to 1D view while projections are displayed