### PR TITLE
NMR-5841 scanner tool not working with JCAMP RS2D

### DIFF
--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/ScanTable.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/ScanTable.java
@@ -230,7 +230,7 @@ public class ScanTable {
                 curLvl.ifPresent(dataAttr::setLvl);
                 int nDim = dataAttr.nDim;
                 chart.full(nDim - 1);
-                if ((nDim - dataAttr.getDataset().getNFreqDims()) == 1){
+                if (chart.getDisDimProperty().get() == PolyChart.DISDIM.OneDX){
                     chart.setDrawlist(rows);
                 } else{
                     chart.clearDrawlist();

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/ScanTable.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/ScanTable.java
@@ -529,6 +529,7 @@ public class ScanTable {
             log.warn("Unable to load dataset, dataset only has 1 dimension.");
             return;
         }
+        scanDir = null;
         // Need to disconnect listeners before updating fileListItem or the selectionListener and filterItemListeners
         // will be triggered during every iteration of the loop, greatly reducing performance
         tableView.getSelectionModel().getSelectedIndices().removeListener(selectionListener);

--- a/nmrfx-bom/pom.xml
+++ b/nmrfx-bom/pom.xml
@@ -23,7 +23,7 @@
             <dependency>
                 <groupId>com.nanalysis</groupId>
                 <artifactId>spinlab-dataset</artifactId>
-                <version>1.2.2</version>
+                <version>1.2.3</version>
                 <!-- license: GPLv3 + Nanalysis internal license -->
             </dependency>
             <dependency>

--- a/nmrfx-bom/pom.xml
+++ b/nmrfx-bom/pom.xml
@@ -138,7 +138,7 @@
             <dependency>
                 <groupId>org.controlsfx</groupId>
                 <artifactId>controlsfx</artifactId>
-                <version>11.1.1</version>
+                <version>11.1.2</version>
                 <!-- license: BSD (3 clause) -->
             </dependency>
             <dependency>

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -316,6 +316,10 @@ public class PolyChart extends Region implements PeakListener {
         return chartSelected.get();
     }
 
+    public ObjectProperty<DISDIM> getDisDimProperty() {
+        return disDimProp;
+    }
+
     public double[][] getCorners() {
         double[][] corners = new double[4][2];
         double xPos = getLayoutX();

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/controls/FileTableItem.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/controls/FileTableItem.java
@@ -260,8 +260,9 @@ public class FileTableItem {
     public String toString(List<String> headers, Map<String, String> columnTypes) {
         StringBuilder sBuilder = new StringBuilder();
         char sepChar = '\t';
+        boolean first = true;
         for (String header : headers) {
-            if (sBuilder.length() > 0) {
+            if (!first) {
                 sBuilder.append(sepChar);
             }
             switch (header.toLowerCase()) {
@@ -311,6 +312,7 @@ public class FileTableItem {
 
                 }
             }
+            first = false;
         }
         return sBuilder.toString();
     }

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/NMRDataUtil.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/NMRDataUtil.java
@@ -261,7 +261,7 @@ public final class NMRDataUtil {
 
         @Override
         public FileVisitResult visitFile(Path file, BasicFileAttributes attr) {
-            if (attr.isRegularFile() && (file.endsWith("fid") || (file.endsWith("ser")) || file.toString().endsWith(".jdx") || file.toString().endsWith(".dx"))) {
+            if (attr.isRegularFile() && (file.endsWith("fid") || (file.endsWith("ser")) || file.toString().endsWith(".jdx") || file.toString().endsWith(".dx") || file.toString().endsWith(RS2DData.DATA_FILE_NAME))) {
                 String fidPath = NMRDataUtil.isFIDDir(file.toString());
                 if (fidPath != null) {
                     fileList.add(fidPath);

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/rs2d/RS2DData.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/rs2d/RS2DData.java
@@ -161,6 +161,7 @@ public class RS2DData implements NMRData {
         Dataset dataset = new Dataset(path.toString(), datasetName, layout,
                 false, ByteOrder.BIG_ENDIAN, 0);
         dataset.newHeader();
+        int numFreqDomain = 0;
         for (int i = 0; i < nDim; i++) {
             resetSW(i);
             dataset.setComplex(i, i == 0);
@@ -170,11 +171,15 @@ public class RS2DData implements NMRData {
             dataset.setRefPt(i, dataset.getSizeReal(i) / 2.0);
             // State can be used to set the freq domain
             dataset.setFreqDomain(i, getState(i) == 1);
+            if (dataset.getFreqDomain(i)) {
+                numFreqDomain++;
+            }
             String nucLabel = getTN(i);
             dataset.setNucleus(i, nucLabel);
             dataset.setLabel(i, nucLabel + (i + 1));
             dataset.syncPars(i);
         }
+        dataset.setNFreqDims(numFreqDomain);
         if (nDim > 1) {
             dataset.setAxisReversed(1, true);
         }


### PR DESCRIPTION
The drawlist was being set based on the number of frequency dimensions. For T1 experiments with .nv datasets, this value is set as 1 (value set from the .par file), for other types of datasets this value is set to the number of dimensions, (since they don't have a par file) so a RS2D t1 has this value set as 2. Since we only differentiate between 2D and pseudo2D by guessing from the number of scans, it would be difficult to set the number of frequency dimensions correctly. Using the chart display type property seems to work for both the .nv files and the JCAMP and RS2D datasets.