### PR TITLE
NMR-5935: set the param STATE in the header when saving RS2D dataset

### DIFF
--- a/nmrfx-bom/pom.xml
+++ b/nmrfx-bom/pom.xml
@@ -23,7 +23,7 @@
             <dependency>
                 <groupId>com.nanalysis</groupId>
                 <artifactId>spinlab-dataset</artifactId>
-                <version>1.2.0</version>
+                <version>1.2.1</version>
                 <!-- license: GPLv3 + Nanalysis internal license -->
             </dependency>
             <dependency>

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/rs2d/RS2DData.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/rs2d/RS2DData.java
@@ -166,7 +166,8 @@ public class RS2DData implements NMRData {
             dataset.setSw(i, getSW(i));
             dataset.setRefValue(i, getRef(i));
             dataset.setRefPt(i, dataset.getSizeReal(i) / 2.0);
-            dataset.setFreqDomain(i, true);
+            // State can be used to set the freq domain
+            dataset.setFreqDomain(i, getState(i) == 1);
             String nucLabel = getTN(i);
             dataset.setNucleus(i, nucLabel);
             dataset.setLabel(i, nucLabel + (i + 1));
@@ -223,15 +224,19 @@ public class RS2DData implements NMRData {
 
     @Override
     public boolean isFID() {
+        return getState(0) == 0;
+    }
+
+    public int getState(int dim) {
         if (header.contains(STATE)) {
             List<Integer> states = header.get(STATE).intListValue();
             if (states != null && !states.isEmpty()) {
-                return states.get(0) == 0;
+                return states.get(dim);
             }
         }
 
         log.debug("Unable to find state parameter. Setting state to FID.");
-        return true;
+        return 0;
     }
 
     private static boolean findFIDFiles(String dirPath) {
@@ -1258,7 +1263,8 @@ public class RS2DData implements NMRData {
         }
         List<Number> stateValues = new ArrayList<>(Collections.nCopies(4, 0));
         for (int i = 0; i< dataset.getNDim(); i++) {
-            stateValues.set(i, 1);
+            int state = dataset.getFreqDomain(i) ? 1 : 0;
+            stateValues.set(i, state);
         }
         header.<ListNumberValue>get(STATE).setValue(stateValues);
 


### PR DESCRIPTION
Header file contents for STATE param set from NMRFx
![image](https://user-images.githubusercontent.com/64663455/200385004-c3e4479f-a73b-4aa2-a6ee-bb2bfd96ac61.png)


Note: this pr based off NMR-5917 because of update to spinlab-dataset
