### PR TITLE
Use nschloe/action-cached-lfs-checkout@v1 to decrease lfs bandwidth u…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Git checkout
-        uses: actions/checkout@v2
+      - name: Checkout code
+        uses: nschloe/action-cached-lfs-checkout@v1
         with:
           token: ${{ secrets.SUBMODULE_ACCESS_TOKEN }}
-          lfs: 'true'
           # Check-out the submodules as well
           submodules: 'recursive'
 


### PR DESCRIPTION
…sage

@carlsonmark discovered the lfs bandwidth was being used a lot by nmrfx since the submodule test data repository was cloned each time. He found a github actions command that will cache the lfs files.

Tested in a separate branch, the left log is a first run of the branch and the right log is the second run of the branch. The second run used the cached lfs
![image](https://user-images.githubusercontent.com/64663455/204389229-fd7ee088-c00a-45ca-939a-f26f75e228ca.png)
