### PR TITLE
NMR 6155 javafx thread exception processing with Contents

### DIFF
--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ContentController.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ContentController.java
@@ -1,5 +1,6 @@
 package org.nmrfx.processor.gui;
 
+import javafx.application.Platform;
 import javafx.collections.ListChangeListener;
 import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableList;
@@ -91,11 +92,13 @@ public class ContentController {
 
     public void update() {
         if (isShowing()) {
-            chart = fxmlController.getActiveChart();
-            chart.setChartDisabled(true);
-            datasetViewController.updateDatasetView();
-            updatePeakView();
-            chart.setChartDisabled(false);
+            Platform.runLater(() -> {
+                        chart = fxmlController.getActiveChart();
+                        chart.setChartDisabled(true);
+                        datasetViewController.updateDatasetView();
+                        updatePeakView();
+                        chart.setChartDisabled(false);
+            });
         }
     }
 


### PR DESCRIPTION
In order for Contents dataset view to be always up to date, it listens to the active projects dataset map. This map is updated from one of the Processor Task threads which results in the GUI getting updated from the non application thread. Moving the update code into Platform.runLater removes the warning.