### PR TITLE
NMR-6346: add null check before reloading data as generated data will…

### DIFF
--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ChartProcessor.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ChartProcessor.java
@@ -1322,10 +1322,14 @@ public class ChartProcessor {
     }
 
     public void reloadData() {
+        NMRData nmrData = getNMRData();
+        if (nmrData == null) {
+            log.info("NMRData is null, unable to reload.");
+            return;
+        }
         chart.setPh0(0);
         chart.setPh1(0);
         chart.setPivot(null);
-        NMRData nmrData = getNMRData();
         int nDim = nmrData.getNDim();
         iVec = 0;
         execScript("", false, false);


### PR DESCRIPTION
… not have a NMRData object associated with them

There was an exception anytime switching to an FID or FID w Ops mode because in the setVecDim call, reloadData is called whenever the processor controller is not viewing a dataset.
Example, without loading anything, switch display mode to spectrum, then back to FID -> results in exception