### PR TITLE
NMR-6351_processing_scan_directory_throws_illegal_argument_exception

### DIFF
--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/ScanTable.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/ScanTable.java
@@ -55,6 +55,7 @@ import org.nmrfx.processor.gui.PolyChart;
 import org.nmrfx.processor.gui.ProcessorController;
 import org.nmrfx.processor.gui.controls.FileTableItem;
 import org.nmrfx.processor.gui.spectra.DatasetAttributes;
+import org.nmrfx.processor.processing.Processor;
 import org.nmrfx.utils.FormatUtils;
 import org.nmrfx.utils.GUIUtils;
 import org.python.util.PythonInterpreter;
@@ -390,6 +391,8 @@ public class ScanTable {
 
             int nDim = fileTableItems.get(0).getNDim();
             String processScript = chartProcessor.buildScript(nDim);
+            Processor processor = Processor.getProcessor();
+            processor.keepDatasetOpen(false);
 
             int rowNum = 1;
             for (FileTableItem fileTableItem : fileTableItems) {


### PR DESCRIPTION
Since we switched to not closing the datasets by default when processing, this caused an issue in the scan table where the dataset files were never created, so when the Scan Table went to load the first dataset after processing the directory, there were no files created.  Setting keepDatasetOpen to false will save the dataset to file after each row of the table is processed