### PR TITLE
NMR-6392: add minor tick gridlines and make all gridlines dashed

### DIFF
--- a/nmrfx-utils/src/main/java/org/nmrfx/chart/Axis.java
+++ b/nmrfx-utils/src/main/java/org/nmrfx/chart/Axis.java
@@ -496,7 +496,7 @@ public class Axis {
                         gC.setLineDashes(GRID_DASHES);
                         gC.strokeLine(x, y1, x, y1 - gridLength);
                         gC.setLineWidth(lineWidth);
-
+                        gC.setLineDashes();
                     }
 
                 } else {
@@ -507,6 +507,7 @@ public class Axis {
                         gC.setLineDashes(GRID_DASHES);
                         gC.strokeLine(x, y1, x, y1 - gridLength);
                         gC.setLineWidth(lineWidth);
+                        gC.setLineDashes();
 
                     }
                 }
@@ -563,6 +564,7 @@ public class Axis {
                         gC.setLineDashes(GRID_DASHES);
                         gC.strokeLine(x1, y, x1 + gridLength, y);
                         gC.setLineWidth(lineWidth);
+                        gC.setLineDashes();
                     }
                 } else {
                     double x2 = x1 - ticSize / 2;
@@ -572,6 +574,7 @@ public class Axis {
                         gC.setLineDashes(GRID_DASHES);
                         gC.strokeLine(x1, y, x1 + gridLength, y);
                         gC.setLineWidth(lineWidth);
+                        gC.setLineDashes();
                     }
                 }
                 if (tInfo.centerMode) {

--- a/nmrfx-utils/src/main/java/org/nmrfx/chart/Axis.java
+++ b/nmrfx-utils/src/main/java/org/nmrfx/chart/Axis.java
@@ -489,7 +489,8 @@ public class Axis {
                         gC.fillText(ticString, x, y2 + gap1);
                     }
                     if (gridLength > 0) {
-                        gC.setLineWidth(0.5);
+                        gC.setLineWidth(1.0);
+                        gC.setLineDashes(1);
                         gC.strokeLine(x, y1, x, y1 - gridLength);
                         gC.setLineWidth(lineWidth);
 
@@ -498,6 +499,13 @@ public class Axis {
                 } else {
                     double y2 = yOrigin + ticSize / 2;
                     gC.strokeLine(x, y1, x, y2);
+                    if (gridLength > 0) {
+                        gC.setLineWidth(0.5);
+                        gC.setLineDashes(1);
+                        gC.strokeLine(x, y1, x, y1 - gridLength);
+                        gC.setLineWidth(lineWidth);
+
+                    }
                 }
                 if (tInfo.centerMode) {
                     break;
@@ -548,13 +556,20 @@ public class Axis {
                         gC.fillText(ticString, x2 - gap1, y);
                     }
                     if (gridLength > 0) {
-                        gC.setLineWidth(0.5);
+                        gC.setLineWidth(1.0);
+                        gC.setLineDashes(1);
                         gC.strokeLine(x1, y, x1 + gridLength, y);
                         gC.setLineWidth(lineWidth);
                     }
                 } else {
                     double x2 = x1 - ticSize / 2;
                     gC.strokeLine(x1, y, x2, y);
+                    if (gridLength > 0) {
+                        gC.setLineWidth(0.5);
+                        gC.setLineDashes(1);
+                        gC.strokeLine(x1, y, x1 + gridLength, y);
+                        gC.setLineWidth(lineWidth);
+                    }
                 }
                 if (tInfo.centerMode) {
                     break;

--- a/nmrfx-utils/src/main/java/org/nmrfx/chart/Axis.java
+++ b/nmrfx-utils/src/main/java/org/nmrfx/chart/Axis.java
@@ -37,6 +37,9 @@ import org.nmrfx.graphicsio.StyledCanvasText;
  * @author brucejohnson
  */
 public class Axis {
+    private static final double GRID_MINOR_LINE_WIDTH = 0.5;
+    private static final double GRID_MAJOR_LINE_WIDTH = 1.0;
+    private static final double GRID_DASHES = 1;
 
     Orientation orientation;
     double ticSize = 10.0;
@@ -489,8 +492,8 @@ public class Axis {
                         gC.fillText(ticString, x, y2 + gap1);
                     }
                     if (gridLength > 0) {
-                        gC.setLineWidth(1.0);
-                        gC.setLineDashes(1);
+                        gC.setLineWidth(GRID_MAJOR_LINE_WIDTH);
+                        gC.setLineDashes(GRID_DASHES);
                         gC.strokeLine(x, y1, x, y1 - gridLength);
                         gC.setLineWidth(lineWidth);
 
@@ -500,8 +503,8 @@ public class Axis {
                     double y2 = yOrigin + ticSize / 2;
                     gC.strokeLine(x, y1, x, y2);
                     if (gridLength > 0) {
-                        gC.setLineWidth(0.5);
-                        gC.setLineDashes(1);
+                        gC.setLineWidth(GRID_MINOR_LINE_WIDTH);
+                        gC.setLineDashes(GRID_DASHES);
                         gC.strokeLine(x, y1, x, y1 - gridLength);
                         gC.setLineWidth(lineWidth);
 
@@ -556,8 +559,8 @@ public class Axis {
                         gC.fillText(ticString, x2 - gap1, y);
                     }
                     if (gridLength > 0) {
-                        gC.setLineWidth(1.0);
-                        gC.setLineDashes(1);
+                        gC.setLineWidth(GRID_MAJOR_LINE_WIDTH);
+                        gC.setLineDashes(GRID_DASHES);
                         gC.strokeLine(x1, y, x1 + gridLength, y);
                         gC.setLineWidth(lineWidth);
                     }
@@ -565,8 +568,8 @@ public class Axis {
                     double x2 = x1 - ticSize / 2;
                     gC.strokeLine(x1, y, x2, y);
                     if (gridLength > 0) {
-                        gC.setLineWidth(0.5);
-                        gC.setLineDashes(1);
+                        gC.setLineWidth(GRID_MINOR_LINE_WIDTH);
+                        gC.setLineDashes(GRID_DASHES);
                         gC.strokeLine(x1, y, x1 + gridLength, y);
                         gC.setLineWidth(lineWidth);
                     }

--- a/nmrfx-utils/src/main/java/org/nmrfx/graphicsio/PDFGraphicsContext.java
+++ b/nmrfx-utils/src/main/java/org/nmrfx/graphicsio/PDFGraphicsContext.java
@@ -640,6 +640,20 @@ public class PDFGraphicsContext implements GraphicsContextInterface {
 
     @Override
     public void setLineDashes(double... dashes) {
+        float[] floatDashes;
+        if (dashes == null) {
+            floatDashes = new float[0];
+        } else {
+            floatDashes = new float[dashes.length];
+            for (int i = 0; i < dashes.length; i++) {
+                floatDashes[i] = (float) dashes[i];
+            }
+        }
+        try {
+            contentStream.setLineDashPattern(floatDashes, (float) 0.0);
+        } catch (IOException ex) {
+            log.error(ex.getMessage(), ex);
+        }
         // throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 

--- a/nmrfx-utils/src/main/java/org/nmrfx/graphicsio/SVGGraphicsContext.java
+++ b/nmrfx-utils/src/main/java/org/nmrfx/graphicsio/SVGGraphicsContext.java
@@ -34,6 +34,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
@@ -60,6 +61,7 @@ public class SVGGraphicsContext implements GraphicsContextInterface {
     Color stroke = Color.BLACK;
     Font font = Font.getDefault();
     double lineWidth = 1.0;
+    double[] lineDashes = null;
     StringBuilder sBuilder = new StringBuilder();
     OutputStream stream;
     XMLStreamWriter writer;
@@ -324,6 +326,11 @@ public class SVGGraphicsContext implements GraphicsContextInterface {
         builder.append("stroke-width: ");
         builder.append(format(lineWidth));
         builder.append(';');
+        if (lineDashes != null && lineDashes.length != 0) {
+            builder.append("stroke-dasharray:");
+            builder.append(String.join(" ", Arrays.stream(lineDashes).mapToObj(this::format).toList()));
+            builder.append(';');
+        }
         if (clipPath.length() != 0) {
             builder.append(clipPath);
         }
@@ -724,7 +731,7 @@ public class SVGGraphicsContext implements GraphicsContextInterface {
 
     @Override
     public void setLineDashes(double... dashes) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        lineDashes = dashes;
     }
 
     @Override


### PR DESCRIPTION
Added fine gridlines and made them dashed. The dash is currently set to 1 but can be adjusted if its too fine of a dash

Before and after 

![gridcomparison](https://user-images.githubusercontent.com/64663455/219435342-1435350d-51ce-4fef-afe9-16b8cf984b92.jpg)

Export to pdf
[test.pdf](https://github.com/nanalysis/nmrfx/files/10768308/test.pdf)
Export to png
![test](https://user-images.githubusercontent.com/64663455/219696257-f97f8ab3-37a3-486c-b399-4b66955347fd.png)
Export to svg
![test](https://user-images.githubusercontent.com/64663455/219696280-fe1c3ed0-7362-476c-93cb-ff1ba87ec822.svg)
