### PR TITLE
NMR-6449 processing in stack display mode causes NPE

### DIFF
--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -1845,13 +1845,6 @@ public class PolyChart extends Region implements PeakListener {
         SpectrumStatusBar statusBar = controller.getStatusBar();
         DatasetAttributes datasetAttributes = null;
         if (dataset != null) {
-            if ((dataset.getNDim() == 1) || (dataset.getNFreqDims() == 1)) {
-                disDimProp.set(DISDIM.OneDX);
-                //statusBar.sliceStatus.setSelected(false);
-                setSliceStatus(false);
-            } else {
-                disDimProp.set(DISDIM.TwoD);
-            }
             if (append) {
                 datasetAttributes = new DatasetAttributes(dataset);
                 if (datasetAttributes.getDataset().isLvlSet()) {
@@ -1891,6 +1884,14 @@ public class PolyChart extends Region implements PeakListener {
                     }
                 }
                 datasetAttributesList.setAll(datasetAttributes);
+            }
+            // Set disDimProp after updating datasetAttributesList as it can trigger listeners
+            // that get the dataset from this chart
+            if ((dataset.getNDim() == 1) || (dataset.getNFreqDims() == 1)) {
+                disDimProp.set(DISDIM.OneDX);
+                setSliceStatus(false);
+            } else {
+                disDimProp.set(DISDIM.TwoD);
             }
             // fixme should we do this
             for (int i = 0; i < datasetAttributes.dim.length; i++) {

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/SpectrumStatusBar.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/SpectrumStatusBar.java
@@ -101,11 +101,7 @@ public class SpectrumStatusBar {
     ComboBox<DisplayMode> displayModeComboBox = null;
     ChangeListener<PolyChart.DISDIM> displayedDimensionsListener = ((observable, oldValue, newValue) -> {
         if (newValue == PolyChart.DISDIM.OneDX) {
-            if (PolyChart.getActiveChart().getDataset().getNDim() > 1) {
-                displayModeComboBox.setValue(DisplayMode.STACKPLOT);
-            } else {
-                displayModeComboBox.setValue(DisplayMode.TRACES);
-            }
+            displayModeComboBox.setValue(DisplayMode.TRACES);
         } else {
             displayModeComboBox.setValue(DisplayMode.CONTOURS);
         }

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/SpectrumStatusBar.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/SpectrumStatusBar.java
@@ -101,7 +101,11 @@ public class SpectrumStatusBar {
     ComboBox<DisplayMode> displayModeComboBox = null;
     ChangeListener<PolyChart.DISDIM> displayedDimensionsListener = ((observable, oldValue, newValue) -> {
         if (newValue == PolyChart.DISDIM.OneDX) {
-            displayModeComboBox.setValue(DisplayMode.TRACES);
+            if (PolyChart.getActiveChart().getDataset().getNDim() < 2) {
+                displayModeComboBox.setValue(DisplayMode.STACKPLOT);
+            } else {
+                displayModeComboBox.setValue(DisplayMode.TRACES);
+            }
         } else {
             displayModeComboBox.setValue(DisplayMode.CONTOURS);
         }

--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/SpectrumStatusBar.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/SpectrumStatusBar.java
@@ -101,7 +101,7 @@ public class SpectrumStatusBar {
     ComboBox<DisplayMode> displayModeComboBox = null;
     ChangeListener<PolyChart.DISDIM> displayedDimensionsListener = ((observable, oldValue, newValue) -> {
         if (newValue == PolyChart.DISDIM.OneDX) {
-            if (PolyChart.getActiveChart().getDataset().getNDim() < 2) {
+            if (PolyChart.getActiveChart().getDataset().getNDim() > 1) {
                 displayModeComboBox.setValue(DisplayMode.STACKPLOT);
             } else {
                 displayModeComboBox.setValue(DisplayMode.TRACES);

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/processing/Processor.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/processing/Processor.java
@@ -1507,20 +1507,21 @@ public class Processor {
         if (dataset.fFormat == DatasetBase.FFORMAT.UCSF) {
             dataset.writeHeader(false);
         }
+
+        int freqDimsProcessed = 0;
+        for (int i = 0; i < dataset.getNDim(); i++) {
+            if (dataset.getFreqDomain(i)) {
+                freqDimsProcessed++;
+            }
+        }
+        dataset.setNFreqDims(freqDimsProcessed);
+        for (int i = nDimsProcessed; i < dataset.getNDim(); i++) {
+            dataset.setComplex(i, false);
+        }
+        if (getNMRData() != null) {
+            dataset.sourceFID(new File(getNMRData().getFilePath()));
+        }
         if (!keepDatasetOpen || !dataset.isMemoryFile()) {
-            int freqDimsProcessed = 0;
-            for (int i = 0; i < dataset.getNDim(); i++) {
-                if (dataset.getFreqDomain(i)) {
-                    freqDimsProcessed++;
-                }
-            }
-            dataset.setNFreqDims(freqDimsProcessed);
-            for (int i = nDimsProcessed; i < dataset.getNDim(); i++) {
-                dataset.setComplex(i, false);
-            }
-            if (getNMRData() != null) {
-                dataset.sourceFID(new File(getNMRData().getFilePath()));
-            }
             if (!dataset.isMemoryFile()) {
                 dataset.writeParFile();
             }


### PR DESCRIPTION
PolyChart.setDataset was setting disDimProp before setting the dataset. disDimProp has a listener that gets the Dataset from PolyChart, so it was retrieving the old dataset which had already been closed/dataFile set to null.

Moved code setting freq dimensions outside of if statement, this seems to allow the right number of spectrums to display when switching to stack plot mode for experiments we have processed