### PR TITLE
NMR-6451 xaxis always defaults to 1H when displaying FIDS with OPs

### DIFF
--- a/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ChartProcessor.java
+++ b/nmrfx-processor-gui/src/main/java/org/nmrfx/processor/gui/ChartProcessor.java
@@ -557,7 +557,9 @@ public class ChartProcessor {
         }
         Vec vec = vectors.get(iVec);
         vec.setName("vec" + iVec);
-        chart.setDataset(new Dataset(vec), false, true);
+        Dataset d = new Dataset(vec);
+        d.setNucleus(0, nmrData.getTN(vecDim));
+        chart.setDataset(d, false, true);
         return fileIndices;
     }
 

--- a/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/NMRDataUtil.java
+++ b/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/NMRDataUtil.java
@@ -255,7 +255,7 @@ public final class NMRDataUtil {
      */
     public static ArrayList guessNucleusFromFreq(final double freq) {
         final double[] Hfreqs = {1000.0, 950.0, 900.0, 800.0, 750.0,
-            700.0, 600.0, 500.0, 400.0, 300.0};
+            700.0, 600.0, 500.0, 400.0, 300.0, 100.0, 60.0};
         HashMap<String, Double> ratio = new LinkedHashMap<>(4);
         ratio.put("1H", 1.0);
         ratio.put("13C", 0.25145004);


### PR DESCRIPTION
The nucleus was always guessed from the function https://github.com/nanalysis/nmrfx/blob/8f1b8916ba60edcfaee51f4cc7e95c2fe765a158/nmrfx-core/src/main/java/org/nmrfx/datasets/Nuclei.java#L320
This function always guessed 1H since it only ever received frequency array of length 1. Instead changed FID w/ops datasets to set the nucleus with the transmit nucleus (How the nucleus is set for the spectrum datasets). Also updated another nuclei guessing function to check the benchtop frequencies as well. 
https://github.com/nanalysis/nmrfx/blob/7dd679447ce3984bee9581d85087bf14db854924/nmrfx-processor/src/main/java/org/nmrfx/processor/datasets/vendor/NMRDataUtil.java#L256
This function is used as a backup when retrieving the transmit nucleus for JCAMPData and BrukerData. The other NMRData do not use it.