### PR TITLE
Nmr 6893 split fxml controller

### DIFF
--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/AnalystApp.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/AnalystApp.java
@@ -80,6 +80,8 @@ public class AnalystApp extends Application {
     private static final PopOverTools popoverTool = new PopOverTools();
     private static final List<Stage> stages = new ArrayList<>();
     private static final String appName = "NMRFx Analyst";
+
+    private static FXMLControllerManager fxmlControllerManager;
     private static PreferencesController preferencesController;
     private static DatasetsController datasetController;
     private static HostServices hostServices;
@@ -725,6 +727,14 @@ public class AnalystApp extends Application {
         } else {
             log.info("Unable to set font size for stage.");
         }
+    }
+
+    public static FXMLControllerManager getFXMLControllerManager() {
+        if (fxmlControllerManager == null) {
+            fxmlControllerManager = new FXMLControllerManager();
+        }
+
+        return fxmlControllerManager;
     }
 
     public static ConsoleController getConsoleController() {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/AnalystApp.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/AnalystApp.java
@@ -112,7 +112,7 @@ public class AnalystApp extends Application {
             startInAdvanced = false;
         }
         analystApp = this;
-        FXMLController.create(stage);
+        getFXMLControllerManager().newController(stage);
 
         Platform.setImplicitExit(true);
         hostServices = getHostServices();
@@ -131,7 +131,7 @@ public class AnalystApp extends Application {
         KeyBindings.registerGlobalKeyAction("pa", this::assignPeak);
         DataFormatHandlerUtil.addHandlersToController();
         ProjectBase.setPCS(new FxPropertyChangeSupport(this));
-        ProjectBase.addPropertyChangeListener(evt -> FXMLController.getControllers().forEach(FXMLController::enableFavoriteButton));
+        ProjectBase.addPropertyChangeListener(evt -> getFXMLControllerManager().getControllers().forEach(FXMLController::enableFavoriteButton));
         PDBFile.setLocalResLibDir(AnalystPrefs.getLocalResidueDirectory());
         RunAboutSaveFrameProcessor runAboutSaveFrameProcessor = new RunAboutSaveFrameProcessor();
         ProjectBase.addSaveframeProcessor("runabout", runAboutSaveFrameProcessor);
@@ -371,7 +371,7 @@ public class AnalystApp extends Application {
     }
 
     private void saveDatasets() {
-        for (var controller: FXMLController.getControllers()) {
+        for (var controller : getFXMLControllerManager().getControllers()) {
             controller.saveDatasets();
         }
     }
@@ -392,7 +392,7 @@ public class AnalystApp extends Application {
     }
 
     private void addAdvancedTools() {
-        for (var controller: FXMLController.getControllers()) {
+        for (var controller : getFXMLControllerManager().getControllers()) {
             addAdvancedTools(controller.getStatusBar());
         }
     }
@@ -424,11 +424,11 @@ public class AnalystApp extends Application {
 
 
         MenuItem spectrumLibraryMenuItem = new MenuItem("Show Spectrum Library");
-        spectrumLibraryMenuItem.disableProperty().bind(FXMLController.activeControllerProperty().isNull());
+        spectrumLibraryMenuItem.disableProperty().bind(getFXMLControllerManager().activeControllerProperty().isNull());
         spectrumLibraryMenuItem.setOnAction(e -> showSpectrumLibrary());
 
         MenuItem spectrumFitLibraryMenuItem = new MenuItem("Show Spectrum Fitter");
-        spectrumFitLibraryMenuItem.disableProperty().bind(FXMLController.activeControllerProperty().isNull());
+        spectrumFitLibraryMenuItem.disableProperty().bind(getFXMLControllerManager().activeControllerProperty().isNull());
         spectrumFitLibraryMenuItem.setOnAction(e -> showSpectrumFitter());
 
         Menu libraryMenu = new Menu("Library");
@@ -456,7 +456,7 @@ public class AnalystApp extends Application {
     }
 
     public void showPeakPathTool() {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         if (!controller.containsTool(PathTool.class)) {
             VBox vBox = new VBox();
             controller.getBottomBox().getChildren().add(vBox);
@@ -467,7 +467,7 @@ public class AnalystApp extends Application {
     }
 
     public void showPeakAssignTool() {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         if (!controller.containsTool(PeakAssignTool.class)) {
             VBox vBox = new VBox();
             controller.getBottomBox().getChildren().add(vBox);
@@ -478,7 +478,7 @@ public class AnalystApp extends Application {
     }
 
     public void showPeakSlider() {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         if (!controller.containsTool(PeakSlider.class)) {
             VBox vBox = new VBox();
             controller.getBottomBox().getChildren().add(vBox);
@@ -489,7 +489,7 @@ public class AnalystApp extends Application {
     }
 
     public void showSpectrumLibrary() {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         if (!controller.containsTool(SimMolController.class)) {
             ToolBar navBar = new ToolBar();
             controller.getBottomBox().getChildren().add(navBar);
@@ -500,7 +500,7 @@ public class AnalystApp extends Application {
     }
 
     public void showSpectrumFitter() {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         if (!controller.containsTool(SimFitMolController.class)) {
             VBox vBox = new VBox();
             controller.getBottomBox().getChildren().add(vBox);
@@ -515,7 +515,7 @@ public class AnalystApp extends Application {
     }
 
     public void showScannerTool() {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         if (!controller.containsTool(ScannerTool.class)) {
             BorderPane vBox = new BorderPane();
             controller.getBottomBox().getChildren().add(vBox);
@@ -527,7 +527,7 @@ public class AnalystApp extends Application {
 
     public void showRunAboutTool() {
         System.out.println("show runabout");
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         if (!controller.containsTool(RunAboutGUI.class)) {
             TabPane tabPane = new TabPane();
             controller.getBottomBox().getChildren().add(tabPane);
@@ -539,7 +539,7 @@ public class AnalystApp extends Application {
     }
 
     public StripController showStripsBar() {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         if (!controller.containsTool(StripController.class)) {
             VBox vBox = new VBox();
             controller.getBottomBox().getChildren().add(vBox);
@@ -551,50 +551,50 @@ public class AnalystApp extends Application {
     }
 
     public void removePeakPathTool(PathTool pathTool) {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         controller.removeTool(PathTool.class);
         controller.getBottomBox().getChildren().remove(pathTool.getBox());
     }
 
     public void removePeakAssignTool(PeakAssignTool peakAssignTool) {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         controller.removeTool(PeakAssignTool.class);
         controller.getBottomBox().getChildren().remove(peakAssignTool.getBox());
     }
 
     public void removePeakSlider(PeakSlider peakSlider) {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         controller.removeTool(PeakSlider.class);
         controller.getBottomBox().getChildren().remove(peakSlider.getBox());
         peakSlider.removeListeners();
     }
 
     public void removeMolSim(SimMolController simMolController) {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         controller.removeTool(SimMolController.class);
         controller.getBottomBox().getChildren().remove(simMolController.getToolBar());
     }
 
     public void removeMolFitter(SimFitMolController simMolController) {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         controller.removeTool(SimFitMolController.class);
         controller.getBottomBox().getChildren().remove(simMolController.getBox());
     }
 
     public void removeScannerTool(ScannerTool scannerTool) {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         controller.removeTool(ScannerTool.class);
         controller.getBottomBox().getChildren().remove(scannerTool.getBox());
     }
 
     public void removeRunaboutTool(RunAboutGUI runaboutTool) {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         controller.removeTool(RunAboutGUI.class);
         controller.getBottomBox().getChildren().remove(runaboutTool.getTabPane());
     }
 
     public void removeStripsBar(StripController stripsController) {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         controller.removeTool(StripController.class);
         controller.getBottomBox().getChildren().remove(stripsController.getBox());
     }
@@ -626,12 +626,12 @@ public class AnalystApp extends Application {
     }
 
     public ScannerTool getScannerTool() {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         return  (ScannerTool) controller.getTool(ScannerTool.class);
     }
 
     public StripController getStripsTool() {
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = getFXMLControllerManager().getOrCreateActiveController();
         return (StripController) controller.getTool(StripController.class);
     }
 
@@ -661,7 +661,7 @@ public class AnalystApp extends Application {
             chart.clearDataAndPeaks();
             chart.clearAnnotations();
         }
-        List<FXMLController> controllers = new ArrayList<>(FXMLController.getControllers());
+        List<FXMLController> controllers = new ArrayList<>(getFXMLControllerManager().getControllers());
         // Don't close the first controller that matches with the main stage, Note this first controller is not
         // necessarily the active controller
         for (int index = 1; index < controllers.size(); index++) {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/DatasetBrowserController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/DatasetBrowserController.java
@@ -26,16 +26,6 @@ package org.nmrfx.analyst.gui;
 import com.jcraft.jsch.JSchException;
 import de.jensd.fx.glyphs.GlyphsDude;
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.ResourceBundle;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
@@ -45,12 +35,7 @@ import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.scene.Scene;
-import javafx.scene.control.Button;
-import javafx.scene.control.ChoiceBox;
-import javafx.scene.control.SelectionMode;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TextField;
-import javafx.scene.control.ToolBar;
+import javafx.scene.control.*;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.HBox;
@@ -60,16 +45,23 @@ import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.util.StringConverter;
 import javafx.util.converter.DefaultStringConverter;
-import org.nmrfx.utilities.RemoteDataset;
 import org.controlsfx.control.tableview2.TableView2;
 import org.nmrfx.processor.datasets.vendor.NMRDataUtil;
 import org.nmrfx.processor.gui.FXMLController;
 import org.nmrfx.processor.gui.controls.ConsoleUtil;
+import org.nmrfx.utilities.RemoteDataset;
 import org.nmrfx.utilities.RemoteDatasetAccess;
 import org.nmrfx.utilities.UnZipper;
 import org.nmrfx.utils.GUIUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.*;
+import java.util.List;
+import java.util.ResourceBundle;
 
 /**
  *
@@ -456,7 +448,7 @@ public class DatasetBrowserController implements Initializable {
                 GUIUtils.warn("Fetch", "File doesn't exist: " + localFile.toString());
                 return;
             }
-            FXMLController controller = FXMLController.getActiveController();
+            FXMLController controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
             try {
                 if (!useFID && !rData.getProcessed().isEmpty()) {
                     File localDataset = fileSystem.getPath(getLocalDir().toString(), fileName, rData.getProcessed()).toFile();

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/FileMenuActions.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/FileMenuActions.java
@@ -3,7 +3,6 @@ package org.nmrfx.analyst.gui;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.stage.Stage;
-import org.nmrfx.processor.gui.FXMLController;
 import org.nmrfx.processor.gui.PreferencesController;
 
 public class FileMenuActions extends MenuActions {
@@ -15,7 +14,7 @@ public class FileMenuActions extends MenuActions {
     @Override
     public void basic() {
         MenuItem openMenuItem = new MenuItem("Open...");
-        openMenuItem.setOnAction(e -> FXMLController.getActiveController().openAction(e));
+        openMenuItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().openAction(e));
 
         Menu recentFilesMenuItem = new Menu("Recent Files");
         menu.setOnShowing(e -> {
@@ -26,16 +25,16 @@ public class FileMenuActions extends MenuActions {
         Menu graphicsMenu = new Menu("Export Graphics");
 
         MenuItem pdfMenuItem = new MenuItem("Export PDF...");
-        pdfMenuItem.disableProperty().bind(FXMLController.activeControllerProperty().isNull());
-        pdfMenuItem.setOnAction(e -> FXMLController.getActiveController().exportPDFAction(e));
+        pdfMenuItem.disableProperty().bind(AnalystApp.getFXMLControllerManager().activeControllerProperty().isNull());
+        pdfMenuItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().exportPDFAction(e));
 
         MenuItem svgMenuItem = new MenuItem("Export SVG...");
-        svgMenuItem.setOnAction(e -> FXMLController.getActiveController().exportSVGAction(e));
-        svgMenuItem.disableProperty().bind(FXMLController.activeControllerProperty().isNull());
+        svgMenuItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().exportSVGAction(e));
+        svgMenuItem.disableProperty().bind(AnalystApp.getFXMLControllerManager().activeControllerProperty().isNull());
 
         MenuItem pngMenuItem = new MenuItem("Export PNG...");
-        pngMenuItem.setOnAction(e -> FXMLController.getActiveController().exportPNG(e));
-        pngMenuItem.disableProperty().bind(FXMLController.activeControllerProperty().isNull());
+        pngMenuItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().exportPNG(e));
+        pngMenuItem.disableProperty().bind(AnalystApp.getFXMLControllerManager().activeControllerProperty().isNull());
 
         graphicsMenu.getItems().addAll(svgMenuItem, pdfMenuItem, pngMenuItem);
 
@@ -57,7 +56,7 @@ public class FileMenuActions extends MenuActions {
     @Override
     protected void advanced() {
         MenuItem addMenuItem = new MenuItem("Open Dataset (No Display) ...");
-        addMenuItem.setOnAction(e -> FXMLController.getActiveController().addNoDrawAction(e));
+        addMenuItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().addNoDrawAction(e));
         menu.getItems().addAll(addMenuItem);
 
     }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/PeakGeneratorGUI.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/PeakGeneratorGUI.java
@@ -10,6 +10,7 @@ import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import org.nmrfx.analyst.gui.peaks.PeakMenuActions;
 import org.nmrfx.analyst.peaks.PeakGenerator;
+import org.nmrfx.analyst.peaks.PeakGenerator.PeakGeneratorTypes;
 import org.nmrfx.chemistry.InvalidMoleculeException;
 import org.nmrfx.datasets.DatasetBase;
 import org.nmrfx.datasets.Nuclei;
@@ -24,8 +25,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.nmrfx.analyst.peaks.PeakGenerator.PeakGeneratorTypes;
 
 import static org.nmrfx.analyst.peaks.PeakGenerator.PeakGeneratorTypes.*;
 
@@ -471,7 +470,8 @@ public class PeakGeneratorGUI {
     }
 
     void showPeakInspector() {
-        FXMLController.getActiveController().showPeakAttr();
-        FXMLController.getActiveController().getPeakAttrController().setPeakList(peakListProperty.get());
+        FXMLController controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
+        controller.showPeakAttr();
+        controller.getPeakAttrController().setPeakList(peakListProperty.get());
     }
 }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/ViewMenuItems.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/ViewMenuItems.java
@@ -6,7 +6,6 @@ import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import org.nmrfx.analyst.gui.regions.RegionsTableController;
 import org.nmrfx.processor.gui.DatasetsController;
-import org.nmrfx.processor.gui.FXMLController;
 import org.nmrfx.processor.gui.project.GUIProject;
 import org.nmrfx.processor.project.Project;
 
@@ -21,7 +20,7 @@ public class ViewMenuItems extends MenuActions {
     @Override
     public void basic() {
         MenuItem procMenuItem = new MenuItem(PROCESSOR_MENU_TEXT);
-        procMenuItem.setOnAction(e -> FXMLController.getActiveController().showProcessorAction(e));
+        procMenuItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().showProcessorAction(e));
 
         MenuItem dataMenuItem = new MenuItem("Show Datasets");
         dataMenuItem.setOnAction(this::showDatasetsTable);
@@ -43,7 +42,7 @@ public class ViewMenuItems extends MenuActions {
     private void verifyMenuItems() {
         for(MenuItem menuItem: menu.getItems()) {
             if (PROCESSOR_MENU_TEXT.equals(menuItem.getText())) {
-                menuItem.setDisable(!FXMLController.getActiveController().isProcessorControllerAvailable());
+                menuItem.setDisable(!AnalystApp.getFXMLControllerManager().getOrCreateActiveController().isProcessorControllerAvailable());
             }
         }
     }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/molecule/MoleculeUtils.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/molecule/MoleculeUtils.java
@@ -1,8 +1,8 @@
 package org.nmrfx.analyst.gui.molecule;
 
 import javafx.scene.control.TextInputDialog;
+import org.nmrfx.analyst.gui.AnalystApp;
 import org.nmrfx.chemistry.MoleculeBase;
-import org.nmrfx.processor.gui.FXMLController;
 import org.nmrfx.processor.gui.PolyChart;
 import org.nmrfx.structure.chemistry.Molecule;
 
@@ -18,7 +18,7 @@ public class MoleculeUtils {
     public static void addActiveMoleculeToCanvas() {
         Molecule activeMol = Molecule.getActive();
         if (activeMol != null) {
-            PolyChart activeChart = FXMLController.getActiveController().getActiveChart();
+            PolyChart activeChart = AnalystApp.getFXMLControllerManager().getOrCreateActiveController().getActiveChart();
             var cMols = activeChart.findAnnoTypes(CanvasMolecule.class);
             CanvasMolecule cMol = null;
             if (cMols.isEmpty()) {
@@ -42,7 +42,7 @@ public class MoleculeUtils {
      * Clears any molecules from the active chart and refreshes it.
      */
     public static void removeMoleculeFromCanvas() {
-        PolyChart chart = FXMLController.getActiveController().getActiveChart();
+        PolyChart chart = AnalystApp.getFXMLControllerManager().getOrCreateActiveController().getActiveChart();
         chart.clearAnnoType(CanvasMolecule.class);
         chart.refresh();
     }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/peaks/PeakAssignTool.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/peaks/PeakAssignTool.java
@@ -182,7 +182,7 @@ public class PeakAssignTool implements ControllerTool {
         removePeakOnClose = peak != null;
         double defaultTol = 0.04;
         Molecule mol = Molecule.getActive();
-        FXMLController fxmlController = FXMLController.getActiveController();
+        FXMLController fxmlController = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
         PolyChart chart = fxmlController.getActiveChart();
         List<Peak> selected = chart.getSelectedPeaks();
         selPeak = null;
@@ -276,7 +276,7 @@ public class PeakAssignTool implements ControllerTool {
             if (selPeak != null) {
                 PeakList peakList = selPeak.getPeakList();
                 peakList.removePeak(selPeak);
-                FXMLController.getActiveController().getActiveChart().drawPeakLists(true);
+                AnalystApp.getFXMLControllerManager().getOrCreateActiveController().getActiveChart().drawPeakLists(true);
             }
         }
     }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/peaks/PeakAtomPicker.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/peaks/PeakAtomPicker.java
@@ -1,8 +1,5 @@
 package org.nmrfx.analyst.gui.peaks;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.ChoiceBox;
@@ -14,7 +11,7 @@ import javafx.scene.layout.HBox;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
-import org.nmrfx.analyst.gui.peaks.AtomBrowser;
+import org.nmrfx.analyst.gui.AnalystApp;
 import org.nmrfx.analyst.gui.peaks.AtomBrowser.AtomDelta;
 import org.nmrfx.datasets.DatasetBase;
 import org.nmrfx.peaks.Peak;
@@ -25,6 +22,10 @@ import org.nmrfx.processor.gui.FXMLController;
 import org.nmrfx.processor.gui.PolyChart;
 import org.nmrfx.processor.gui.spectra.PeakListAttributes;
 import org.nmrfx.structure.chemistry.Molecule;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -114,7 +115,7 @@ public class PeakAtomPicker {
                 choiceBox.getItems().setAll(mol.entities.keySet());
             }
         }
-        FXMLController fxmlController = FXMLController.getActiveController();
+        FXMLController fxmlController = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
         PolyChart chart = fxmlController.getActiveChart();
         List<Peak> selected = chart.getSelectedPeaks();
         selPeak = null;
@@ -168,7 +169,7 @@ public class PeakAtomPicker {
             if (selPeak != null) {
                 PeakList peakList = selPeak.getPeakList();
                 peakList.removePeak(selPeak);
-                FXMLController.getActiveController().getActiveChart().drawPeakLists(true);
+                AnalystApp.getFXMLControllerManager().getOrCreateActiveController().getActiveChart().drawPeakLists(true);
             }
         }
         stage.close();

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/peaks/PeakListsTableController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/peaks/PeakListsTableController.java
@@ -98,8 +98,9 @@ public class PeakListsTableController implements Initializable {
     void showPeakInspector() {
         PeakList peakList = peakListsTable.getSelectionModel().getSelectedItem();
         if (peakList != null) {
-            FXMLController.getActiveController().showPeakAttr();
-            FXMLController.getActiveController().getPeakAttrController().setPeakList(peakList);
+            FXMLController controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
+            controller.showPeakAttr();
+            controller.getPeakAttrController().setPeakList(peakList);
         }
     }
 

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/peaks/PeakMenuActions.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/peaks/PeakMenuActions.java
@@ -37,7 +37,7 @@ public class PeakMenuActions extends MenuActions {
     @Override
     public void basic() {
         MenuItem peakAttrMenuItem = new MenuItem("Show Peak Tool");
-        peakAttrMenuItem.setOnAction(e -> FXMLController.getActiveController().showPeakAttrAction(e));
+        peakAttrMenuItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().showPeakAttrAction(e));
 
         MenuItem peakTableMenuItem = new MenuItem("Show Peak Table");
         peakTableMenuItem.setOnAction(e -> showPeakTable());
@@ -55,10 +55,10 @@ public class PeakMenuActions extends MenuActions {
         peakGeneratorMenuItem.setOnAction(e -> showPeakGeneratorGUI());
 
         MenuItem linkPeakDimsMenuItem = new MenuItem("Link by Labels");
-        linkPeakDimsMenuItem.setOnAction(e -> FXMLController.getActiveController().linkPeakDims());
+        linkPeakDimsMenuItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().linkPeakDims());
 
         MenuItem ligandScannerMenuItem = new MenuItem("Show Ligand Scanner");
-        ligandScannerMenuItem.disableProperty().bind(FXMLController.activeControllerProperty().isNull());
+        ligandScannerMenuItem.disableProperty().bind(AnalystApp.getFXMLControllerManager().activeControllerProperty().isNull());
         ligandScannerMenuItem.setOnAction(e -> showLigandScanner());
 
         MenuItem noeTableMenuItem = new MenuItem("Show NOE Table");
@@ -69,7 +69,7 @@ public class PeakMenuActions extends MenuActions {
         assignOnPick = new CheckMenuItem("Assign on Pick");
 
         MenuItem atomBrowserMenuItem = new MenuItem("Show Atom Browser");
-        atomBrowserMenuItem.disableProperty().bind(FXMLController.activeControllerProperty().isNull());
+        atomBrowserMenuItem.disableProperty().bind(AnalystApp.getFXMLControllerManager().activeControllerProperty().isNull());
         atomBrowserMenuItem.setOnAction(e -> showAtomBrowser());
 
         MenuItem runAboutMenuItem = new MenuItem("Show RunAboutX");
@@ -146,7 +146,7 @@ public class PeakMenuActions extends MenuActions {
     public void showAtomBrowser() {
         if (atomBrowser == null) {
             ToolBar navBar = new ToolBar();
-            FXMLController controller = FXMLController.getActiveController();
+            FXMLController controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
             controller.getBottomBox().getChildren().add(navBar);
             atomBrowser = new AtomBrowser(controller, this::removeAtomBrowser);
             atomBrowser.initSlider(navBar);
@@ -155,7 +155,7 @@ public class PeakMenuActions extends MenuActions {
 
     public void removeAtomBrowser(Object o) {
         if (atomBrowser != null) {
-            FXMLController controller = FXMLController.getActiveController();
+            FXMLController controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
             controller.getBottomBox().getChildren().remove(atomBrowser.getToolBar());
             atomBrowser = null;
         }
@@ -164,7 +164,7 @@ public class PeakMenuActions extends MenuActions {
         if (assignOnPick.isSelected()) {
             Peak peak = (Peak) peakObject;
             System.out.println(peak.getName());
-            PolyChart chart = FXMLController.getActiveController().getActiveChart();
+            PolyChart chart = AnalystApp.getFXMLControllerManager().getOrCreateActiveController().getActiveChart();
             double x = chart.getMouseX();
             double y = chart.getMouseY();
             Canvas canvas = chart.getCanvas();

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/peaks/PeakTableController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/peaks/PeakTableController.java
@@ -23,60 +23,52 @@
  */
 package org.nmrfx.analyst.gui.peaks;
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.ResourceBundle;
+import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
+import javafx.collections.MapChangeListener;
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.scene.Scene;
-import javafx.scene.control.Button;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableRow;
-import javafx.scene.control.TableView;
-import javafx.scene.control.ToolBar;
+import javafx.scene.control.*;
+import javafx.scene.control.TableColumn.CellDataFeatures;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.control.cell.TextFieldTableCell;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
-import javafx.scene.layout.Pane;
-import javafx.stage.Stage;
-import javafx.stage.StageStyle;
-import java.text.DecimalFormat;
-import java.text.Format;
-import javafx.beans.property.ReadOnlyObjectWrapper;
-import javafx.collections.FXCollections;
-import javafx.collections.ListChangeListener;
-import javafx.collections.MapChangeListener;
-import javafx.collections.ObservableList;
-import javafx.scene.control.ColorPicker;
-import javafx.scene.control.Label;
-import javafx.scene.control.MenuButton;
-import javafx.scene.control.MenuItem;
-import javafx.scene.control.SelectionMode;
-import javafx.scene.control.TableCell;
-import javafx.scene.control.TableColumn.CellDataFeatures;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
 import javafx.util.Callback;
 import javafx.util.StringConverter;
 import javafx.util.converter.DefaultStringConverter;
+import org.nmrfx.analyst.gui.AnalystApp;
 import org.nmrfx.peaks.Multiplet;
 import org.nmrfx.peaks.Peak;
 import org.nmrfx.peaks.PeakDim;
-import org.nmrfx.peaks.events.PeakEvent;
 import org.nmrfx.peaks.PeakList;
+import org.nmrfx.peaks.events.PeakEvent;
 import org.nmrfx.peaks.events.PeakListener;
 import org.nmrfx.processor.gui.FXMLController;
 import org.nmrfx.processor.gui.PeakMenuBar;
 import org.nmrfx.processor.gui.PeakMenuTarget;
 import org.nmrfx.processor.project.Project;
 import org.nmrfx.utils.TableUtils;
+
+import java.io.IOException;
+import java.net.URL;
+import java.text.DecimalFormat;
+import java.text.Format;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ResourceBundle;
 
 /**
  *
@@ -459,9 +451,10 @@ public class PeakTableController implements PeakMenuTarget, PeakListener, Initia
     }
 
     void showPeakInfo(Peak peak) {
-        FXMLController.getActiveController().showPeakAttr();
-        FXMLController.getActiveController().getPeakAttrController().gotoPeak(peak);
-        FXMLController.getActiveController().getPeakAttrController().getStage().toFront();
+        FXMLController controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
+        controller.showPeakAttr();
+        controller.getPeakAttrController().gotoPeak(peak);
+        controller.getPeakAttrController().getStage().toFront();
 
     }
 

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/spectra/SpectrumMenuActions.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/spectra/SpectrumMenuActions.java
@@ -7,7 +7,6 @@ import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import org.nmrfx.analyst.gui.AnalystApp;
 import org.nmrfx.analyst.gui.MenuActions;
-import org.nmrfx.processor.gui.FXMLController;
 import org.nmrfx.processor.gui.PolyChart;
 import org.nmrfx.processor.gui.controls.GridPaneCanvas;
 import org.nmrfx.processor.gui.spectra.WindowIO;
@@ -35,42 +34,42 @@ public class SpectrumMenuActions extends MenuActions {
 
 
         MenuItem deleteItem = new MenuItem("Delete Spectrum");
-        deleteItem.setOnAction(e -> FXMLController.getActiveController().removeSelectedChart());
+        deleteItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().removeSelectedChart());
         MenuItem syncMenuItem = new MenuItem("Sync Axes");
         syncMenuItem.setOnAction(e -> PolyChart.getActiveChart().syncSceneMates());
 
         Menu arrangeMenu = new Menu("Arrange");
         MenuItem createGridItem = new MenuItem("Add Grid...");
-        createGridItem.setOnAction(e -> FXMLController.getActiveController().addGrid());
+        createGridItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().addGrid());
         MenuItem horizItem = new MenuItem("Horizontal");
-        horizItem.setOnAction(e -> FXMLController.getActiveController().arrange(GridPaneCanvas.ORIENTATION.HORIZONTAL));
+        horizItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().arrange(GridPaneCanvas.ORIENTATION.HORIZONTAL));
         MenuItem vertItem = new MenuItem("Vertical");
-        vertItem.setOnAction(e -> FXMLController.getActiveController().arrange(GridPaneCanvas.ORIENTATION.VERTICAL));
+        vertItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().arrange(GridPaneCanvas.ORIENTATION.VERTICAL));
         MenuItem gridItem = new MenuItem("Grid");
-        gridItem.setOnAction(e -> FXMLController.getActiveController().arrange(GridPaneCanvas.ORIENTATION.GRID));
+        gridItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().arrange(GridPaneCanvas.ORIENTATION.GRID));
         MenuItem overlayItem = new MenuItem("Overlay");
-        overlayItem.setOnAction(e -> FXMLController.getActiveController().overlay());
+        overlayItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().overlay());
         MenuItem minimizeItem = new MenuItem("Minimize Borders");
-        minimizeItem.setOnAction(e -> FXMLController.getActiveController().setBorderState(true));
+        minimizeItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().setBorderState(true));
         MenuItem normalizeItem = new MenuItem("Normal Borders");
-        normalizeItem.setOnAction(e -> FXMLController.getActiveController().setBorderState(false));
+        normalizeItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().setBorderState(false));
 
         arrangeMenu.getItems().addAll(createGridItem, horizItem, vertItem, gridItem, overlayItem, minimizeItem, normalizeItem);
         MenuItem favoritesMenuItem = new MenuItem("Favorites");
         favoritesMenuItem.setOnAction(e -> showFavorites());
         MenuItem copyItem = new MenuItem("Copy Spectrum as SVG");
-        copyItem.setOnAction(e -> FXMLController.getActiveController().copySVGAction(e));
+        copyItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().copySVGAction(e));
         menu.getItems().addAll(newMenuItem, deleteItem, arrangeMenu, favoritesMenuItem, syncMenuItem, copyItem);
         MenuItem[] disableItems = {deleteItem, arrangeMenu, favoritesMenuItem, syncMenuItem, copyItem};
         for (var item:disableItems) {
-            item.disableProperty().bind(FXMLController.activeControllerProperty().isNull());
+            item.disableProperty().bind(AnalystApp.getFXMLControllerManager().activeControllerProperty().isNull());
         }
     }
 
     @Override
     protected void advanced() {
         MenuItem alignMenuItem = new MenuItem("Align Spectra");
-        alignMenuItem.setOnAction(e -> FXMLController.getActiveController().alignCenters());
+        alignMenuItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().alignCenters());
 
         menu.getItems().addAll(
                 alignMenuItem);
@@ -101,6 +100,6 @@ public class SpectrumMenuActions extends MenuActions {
     private void newGraphics(ActionEvent event) {
         Stage stage = new Stage(StageStyle.DECORATED);
         stage.setTitle(AnalystApp.getAppName() + " " + AnalystApp.getVersion());
-        FXMLController.create(stage);
+        AnalystApp.getFXMLControllerManager().newController(stage);
     }
 }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/JournalTool.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/JournalTool.java
@@ -5,9 +5,9 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import org.controlsfx.control.PopOver;
+import org.nmrfx.analyst.gui.AnalystApp;
 import org.nmrfx.analyst.gui.annotations.AnnoJournalFormat;
 import org.nmrfx.analyst.peaks.JournalFormatPeaks;
-import org.nmrfx.processor.gui.FXMLController;
 import org.nmrfx.processor.gui.PolyChart;
 
 public class JournalTool {
@@ -60,6 +60,6 @@ public class JournalTool {
         if (annoJournalFormat != null) {
             annoJournalFormat.setJournalName(journalName);
         }
-        FXMLController.getActiveController().getActiveChart().refresh();
+        AnalystApp.getFXMLControllerManager().getOrCreateActiveController().getActiveChart().refresh();
     }
 }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/PeakSlider.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/PeakSlider.java
@@ -1279,7 +1279,7 @@ public class PeakSlider implements ControllerTool {
             }
         } finally {
             PolyChart.setPeakListenerState(true);
-            for (FXMLController fxmlController : FXMLController.getControllers()) {
+            for (FXMLController fxmlController : AnalystApp.getFXMLControllerManager().getControllers()) {
                 fxmlController.redrawChildren();
             }
         }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/RunAboutGUI.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/RunAboutGUI.java
@@ -1276,7 +1276,7 @@ public class RunAboutGUI implements PeakListener, ControllerTool {
     public void setPeakList() {
         if (navigationPeakList == null) {
             PeakList testList = null;
-            FXMLController controller = FXMLController.getActiveController();
+            FXMLController controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
             PolyChart chart = controller.getActiveChart();
             if (chart != null) {
                 ObservableList<PeakListAttributes> attr = chart.getPeakListAttributes();
@@ -1764,7 +1764,7 @@ public class RunAboutGUI implements PeakListener, ControllerTool {
 
     void showRefChart() {
         if (runAbout.isActive()) {
-            refController = FXMLController.create();
+            refController = AnalystApp.getFXMLControllerManager().newController();
             PeakList refList = runAbout.getPeakLists().get(0);
             String datasetName = refList.getDatasetName();
             Dataset dataset = Dataset.getDataset(datasetName);

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/ScanTable.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/analyst/gui/tools/ScanTable.java
@@ -43,6 +43,7 @@ import org.controlsfx.control.PopOver;
 import org.controlsfx.control.table.ColumnFilter;
 import org.controlsfx.control.table.TableFilter;
 import org.controlsfx.dialog.ExceptionDialog;
+import org.nmrfx.analyst.gui.AnalystApp;
 import org.nmrfx.datasets.DatasetBase;
 import org.nmrfx.processor.datasets.Dataset;
 import org.nmrfx.processor.datasets.DatasetException;
@@ -50,7 +51,6 @@ import org.nmrfx.processor.datasets.DatasetMerger;
 import org.nmrfx.processor.datasets.vendor.NMRData;
 import org.nmrfx.processor.datasets.vendor.NMRDataUtil;
 import org.nmrfx.processor.gui.ChartProcessor;
-import org.nmrfx.processor.gui.FXMLController;
 import org.nmrfx.processor.gui.PolyChart;
 import org.nmrfx.processor.gui.ProcessorController;
 import org.nmrfx.processor.gui.controls.FileTableItem;
@@ -192,7 +192,7 @@ public class ScanTable {
                 Dataset dataset = Dataset.getDataset(datasetName);
                 if (dataset == null) {
                     File datasetFile = new File(scanDir, datasetPath);
-                    FXMLController.getActiveController().openDataset(datasetFile, false, true);
+                    AnalystApp.getFXMLControllerManager().getOrCreateActiveController().openDataset(datasetFile, false, true);
                 }
             }
         }
@@ -467,7 +467,7 @@ public class ScanTable {
                     // After merging, remove the 1D files
                     for (String fileName : fileNames) {
                         File file = new File(fileName);
-                        FXMLController.getActiveController().closeFile(file);
+                        AnalystApp.getFXMLControllerManager().getOrCreateActiveController().closeFile(file);
                         Files.deleteIfExists(file.toPath());
                         String parFileName = fileName.substring(0, fileName.lastIndexOf(".")) + ".par";
                         File parFile = new File(parFileName);
@@ -475,7 +475,7 @@ public class ScanTable {
                     }
 
                     // load merged dataset
-                    FXMLController.getActiveController().openDataset(mergedFile, false, true);
+                    AnalystApp.getFXMLControllerManager().getOrCreateActiveController().openDataset(mergedFile, false, true);
                     List<Integer> rows = new ArrayList<>();
                     rows.add(0);
                     chart.setDrawlist(rows);
@@ -486,7 +486,7 @@ public class ScanTable {
             } else {
                 // load first output dataset
                 File datasetFile = new File(scanOutputDir, fileRoot + 1 + ".nv");
-                FXMLController.getActiveController().openDataset(datasetFile, false, true);
+                AnalystApp.getFXMLControllerManager().getOrCreateActiveController().openDataset(datasetFile, false, true);
             }
             chart.full();
             chart.autoScale();
@@ -755,7 +755,7 @@ public class ScanTable {
                 File parentDir = file.getParentFile();
                 Path path = FileSystems.getDefault().getPath(parentDir.toString(), firstDatasetName);
                 if (path.toFile().exists()) {
-                    Dataset firstDataset = FXMLController.getActiveController().openDataset(path.toFile(), false, true);
+                    Dataset firstDataset = AnalystApp.getFXMLControllerManager().getOrCreateActiveController().openDataset(path.toFile(), false, true);
                     // If there is only one unique dataset name, assume an arrayed experiment
                     List<String> uniqueDatasetNames = new ArrayList<>(fileListItems.stream().map(FileTableItem::getDatasetName).collect(Collectors.toSet()));
                     if (uniqueDatasetNames.size() == 1 && uniqueDatasetNames.get(0) != null && !uniqueDatasetNames.get(0).equals("")) {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/DatasetsController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/DatasetsController.java
@@ -52,6 +52,7 @@ import javafx.stage.StageStyle;
 import javafx.util.StringConverter;
 import javafx.util.converter.DefaultStringConverter;
 import javafx.util.converter.DoubleStringConverter;
+import org.nmrfx.analyst.gui.AnalystApp;
 import org.nmrfx.datasets.DatasetBase;
 import org.nmrfx.processor.gui.controls.GridPaneCanvas;
 import org.nmrfx.project.ProjectBase;
@@ -457,10 +458,10 @@ public class DatasetsController implements Initializable, PropertyChangeListener
 
     void drawDataset(ActionEvent e) {
         ObservableList<DatasetBase> datasets = tableView.getSelectionModel().getSelectedItems();
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
         PolyChart chart = controller.getActiveChart();
         if ((chart != null) && chart.getDataset() != null) {
-            controller = FXMLController.create();
+            controller = AnalystApp.getFXMLControllerManager().newController();
         }
         boolean appendFile = false;
         for (DatasetBase dataset : datasets) {
@@ -471,10 +472,10 @@ public class DatasetsController implements Initializable, PropertyChangeListener
 
     void gridDataset(GridPaneCanvas.ORIENTATION orient) {
         ObservableList<DatasetBase> datasets = tableView.getSelectionModel().getSelectedItems();
-        FXMLController controller = FXMLController.getActiveController();
+        FXMLController controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
         PolyChart chart = controller.getActiveChart();
         if ((chart != null) && chart.getDataset() != null) {
-            controller = FXMLController.create();
+            controller = AnalystApp.getFXMLControllerManager().newController();
         }
         controller.setNCharts(datasets.size());
         controller.arrange(orient);

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -1872,11 +1872,6 @@ public class FXMLController implements Initializable, PeakNavigable {
         }
     }
 
-    public static List<FXMLController> getControllers() {
-        //XXX inline this call
-        return AnalystApp.getFXMLControllerManager().getControllers();
-    }
-
     public static PeakAttrController getPeakAttrController() {
         return peakAttrController;
     }
@@ -1903,29 +1898,9 @@ public class FXMLController implements Initializable, PeakNavigable {
         return docString;
     }
 
-    public static SimpleObjectProperty<FXMLController> activeControllerProperty() {
-        //XXX inline this call
-        return AnalystApp.getFXMLControllerManager().activeControllerProperty();
-    }
-
-    public static FXMLController getActiveController() {
-        //XXX inline this call
-        return AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
-    }
-
     private void setActiveController(Observable obs) {
         if (stage.isFocused()) {
             setActiveController();
         }
-    }
-
-    public static FXMLController create() {
-        //XXX inline this call
-        return AnalystApp.getFXMLControllerManager().newController();
-    }
-
-    public static FXMLController create(Stage stage) {
-        //XXX inline this call
-        return AnalystApp.getFXMLControllerManager().newController(stage);
     }
 }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -912,7 +912,6 @@ public class FXMLController implements Initializable, PeakNavigable {
 
         stage.focusedProperty().addListener(this::setActiveController);
         stage.maximizedProperty().addListener(this::adjustSizeAfterMaximize);
-        setActiveController();
     }
 
 

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -160,6 +160,11 @@ public class FXMLController implements Initializable, PeakNavigable {
         return bgColorProperty().get();
     }
 
+    @SuppressWarnings("unchecked") // called by reflection using PropertyUtils
+    public void setBgColor(Color bgColor) {
+        bgColorProperty().set(bgColor);
+    }
+
     private ColorProperty bgColorProperty() {
         if (bgColor == null) {
             bgColor = new ColorProperty(this, "bgColor", null);
@@ -185,6 +190,12 @@ public class FXMLController implements Initializable, PeakNavigable {
 
     public Color getAxesColor() {
         return axesColorProperty().get();
+    }
+
+    // called by reflection using PropertyUtils
+    @SuppressWarnings("unchecked")
+    public void setAxesColor(Color axesColor) {
+        this.axesColorProperty().set(axesColor);
     }
 
     private ColorProperty axesColorProperty() {
@@ -1194,11 +1205,11 @@ public class FXMLController implements Initializable, PeakNavigable {
         return bordersGrid;
     }
 
-    private boolean getMinBorders() {
+    public boolean getMinBorders() {
         return minBordersProperty().get();
     }
 
-    private void setMinBorders(boolean value) {
+    public void setMinBorders(boolean value) {
         minBordersProperty().set(value);
     }
 
@@ -1401,6 +1412,7 @@ public class FXMLController implements Initializable, PeakNavigable {
     }
 
     public Map<String, Object> config() {
+        //TODO remove use of reflection/PropertyUtils here, since the property names are fixed!
         Map<String, Object> data = new HashMap<>();
         String[] beanNames = {"bgColor", "axesColor", "minBorders"};
         for (String beanName : beanNames) {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -878,8 +878,6 @@ public class FXMLController implements Initializable, PeakNavigable {
             chartGroup.requestLayout();
         });
 
-        //XXX this should likely be removed from here and moved to FXMLControllerManager during component creation
-        AnalystApp.getFXMLControllerManager().register(this, true);
         statusBar.setMode(1);
         for (int iCross = 0; iCross < 2; iCross++) {
             for (int jOrient = 0; jOrient < 2; jOrient++) {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -215,7 +215,7 @@ public class FXMLController implements Initializable, PeakNavigable {
             chart.close();
         }
 
-        FXMLControllerManager.getInstance().unregister(this);
+        AnalystApp.getFXMLControllerManager().unregister(this);
         PolyChart activeChart = PolyChart.getActiveChart();
         if (activeChart == null) {
             if (!PolyChart.CHARTS.isEmpty()) {
@@ -223,7 +223,7 @@ public class FXMLController implements Initializable, PeakNavigable {
             }
         }
 
-        FXMLControllerManager.getInstance().setActiveControllerFromChart(activeChart);
+        AnalystApp.getFXMLControllerManager().setActiveControllerFromChart(activeChart);
     }
 
     public void saveDatasets() {
@@ -882,7 +882,7 @@ public class FXMLController implements Initializable, PeakNavigable {
             chartGroup.requestLayout();
         });
 
-        FXMLControllerManager.getInstance().register(this, true);
+        AnalystApp.getFXMLControllerManager().register(this, true);
         statusBar.setMode(1);
         for (int iCross = 0; iCross < 2; iCross++) {
             for (int jOrient = 0; jOrient < 2; jOrient++) {
@@ -1789,7 +1789,7 @@ public class FXMLController implements Initializable, PeakNavigable {
     }
 
     public void setActiveController() {
-        FXMLControllerManager.getInstance().setActiveController(this);
+        AnalystApp.getFXMLControllerManager().setActiveController(this);
         if (attributesController != null) {
             attributesController.setAttributeControls();
         }
@@ -1860,7 +1860,7 @@ public class FXMLController implements Initializable, PeakNavigable {
 
     public static List<FXMLController> getControllers() {
         //XXX inline this call
-        return FXMLControllerManager.getInstance().getControllers();
+        return AnalystApp.getFXMLControllerManager().getControllers();
     }
 
     public static PeakAttrController getPeakAttrController() {
@@ -1891,12 +1891,12 @@ public class FXMLController implements Initializable, PeakNavigable {
 
     public static SimpleObjectProperty<FXMLController> activeControllerProperty() {
         //XXX inline this call
-        return FXMLControllerManager.getInstance().activeControllerProperty();
+        return AnalystApp.getFXMLControllerManager().activeControllerProperty();
     }
 
     public static FXMLController getActiveController() {
         //XXX inline this call
-        return FXMLControllerManager.getInstance().getOrCreateActiveController();
+        return AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
     }
 
     private void setActiveController(Observable obs) {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLControllerManager.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLControllerManager.java
@@ -9,7 +9,6 @@ import javafx.stage.StageStyle;
 import org.nmrfx.analyst.gui.AnalystApp;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -20,9 +19,11 @@ import java.util.Set;
  * Manages instances of FXMLControllers, from creation to listing them and keeping a way to know which one is the active one.
  */
 public class FXMLControllerManager {
+    // The active controller is the last one created, or the one that has focus
     private final SimpleObjectProperty<FXMLController> activeController = new SimpleObjectProperty<>(null);
 
-    // it is important to keep insertion order: the first controller is considered the main one and is kept when closing all secondary stages
+    // A collection of all known controllers.
+    // It is important to keep insertion order: the first controller is considered the main one and is kept when closing all secondary stages
     private final Set<FXMLController> controllers = new LinkedHashSet<>();
 
     public Collection<FXMLController> getControllers() {
@@ -48,16 +49,15 @@ public class FXMLControllerManager {
     public FXMLController getOrCreateActiveController() {
         FXMLController active = activeController.get();
         if (active == null) {
+            //XXX is there actually a case where not having an active controller is a possibility?
             active = newController();
+
+            //XXX in which case could we not already be the active controller here?
+            //XXX it looks like creating a controller already sets it as active
             setActiveController(active);
         }
 
         return active;
-    }
-
-    @Nullable
-    public FXMLController getActiveController() {
-        return activeController.get();
     }
 
     public SimpleObjectProperty<FXMLController> activeControllerProperty() {
@@ -65,7 +65,10 @@ public class FXMLControllerManager {
     }
 
     public void setActiveController(FXMLController controller) {
-        //XXX check or add in all controllers list?
+        if (!controllers.contains(controller)) {
+            throw new IllegalStateException("Trying to set an unregistered controller as the active one!");
+        }
+
         activeController.set(controller);
     }
 

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLControllerManager.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLControllerManager.java
@@ -1,0 +1,85 @@
+package org.nmrfx.processor.gui;
+
+import javafx.beans.property.SimpleObjectProperty;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Manages instances of FXMLControllers
+ */
+public class FXMLControllerManager {
+    private static FXMLControllerManager instance;
+
+    public static FXMLControllerManager getInstance() {
+        //XXX keep as singleton, or move to AnalystApp ?
+        if (instance == null) {
+            instance = new FXMLControllerManager();
+        }
+
+        return instance;
+    }
+
+    private final SimpleObjectProperty<FXMLController> activeController = new SimpleObjectProperty<>(null);
+    private final List<FXMLController> controllers = new ArrayList<>(); //XXX can we use a set instead?
+
+    public List<FXMLController> getControllers() {
+        //XXX see if we could make it unmodifiable here
+        return controllers;
+    }
+
+    @Nonnull
+    public FXMLController getOrCreateActiveController() {
+        FXMLController active = activeController.get();
+        if (active == null) {
+            active = FXMLController.create();
+            setActiveController(active);
+
+            //XXX see if this call is necessary for its side effects
+            active.setActiveController();
+        }
+
+        return active;
+    }
+
+    @Nullable
+    public FXMLController getActiveController() {
+        return activeController.get();
+    }
+
+    public SimpleObjectProperty<FXMLController> activeControllerProperty() {
+        return activeController;
+    }
+
+    public void register(FXMLController controller) {
+        register(controller, false);
+    }
+
+    public void register(FXMLController controller, boolean active) {
+        controllers.add(controller);
+        if (active) {
+            activeController.set(controller);
+        }
+    }
+
+    public void unregister(FXMLController controller) {
+        controllers.remove(controller);
+    }
+
+    public void setActiveController(FXMLController controller) {
+        //XXX check or add in all controllers list?
+        activeController.set(controller);
+    }
+
+    public void setActiveControllerFromChart(PolyChart chart) {
+        if (chart == null || chart.getController() == null) {
+            setActiveController(null);
+        } else {
+            setActiveController(chart.getController());
+            chart.getController().setActiveChart(chart);
+        }
+    }
+
+}

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLControllerManager.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLControllerManager.java
@@ -1,9 +1,16 @@
 package org.nmrfx.processor.gui;
 
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+import org.nmrfx.analyst.gui.AnalystApp;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -71,4 +78,33 @@ public class FXMLControllerManager {
         }
     }
 
+
+    public FXMLController newController() {
+        return newController(new Stage(StageStyle.DECORATED));
+    }
+
+    public FXMLController newController(Stage stage) {
+        FXMLLoader loader = new FXMLLoader(FXMLController.class.getResource("/fxml/NMRScene.fxml"));
+        FXMLController controller;
+
+
+        try {
+            //XXX this could be simplified
+            Parent parent = loader.load();
+            Scene scene = new Scene(parent);
+            stage.setScene(scene);
+            scene.getStylesheets().add("/styles/Styles.css");
+            AnalystApp.setStageFontSize(stage, AnalystApp.REG_FONT_SIZE_STR);
+            controller = loader.getController();
+            controller.initAfterFxmlLoader(stage);
+
+
+            AnalystApp.registerStage(stage, controller);
+            stage.show();
+        } catch (IOException ioE) {
+            throw new IllegalStateException("Unable to create controller", ioE);
+        }
+
+        return controller;
+    }
 }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLControllerManager.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLControllerManager.java
@@ -8,20 +8,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Manages instances of FXMLControllers
+ * Manages instances of FXMLControllers, from creation to listing them and keeping a way to know which one is the active one.
  */
 public class FXMLControllerManager {
-    private static FXMLControllerManager instance;
-
-    public static FXMLControllerManager getInstance() {
-        //XXX keep as singleton, or move to AnalystApp ?
-        if (instance == null) {
-            instance = new FXMLControllerManager();
-        }
-
-        return instance;
-    }
-
     private final SimpleObjectProperty<FXMLController> activeController = new SimpleObjectProperty<>(null);
     private final List<FXMLController> controllers = new ArrayList<>(); //XXX can we use a set instead?
 

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLControllerManager.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLControllerManager.java
@@ -11,19 +11,22 @@ import org.nmrfx.analyst.gui.AnalystApp;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * Manages instances of FXMLControllers, from creation to listing them and keeping a way to know which one is the active one.
  */
 public class FXMLControllerManager {
     private final SimpleObjectProperty<FXMLController> activeController = new SimpleObjectProperty<>(null);
-    private final List<FXMLController> controllers = new ArrayList<>(); //XXX can we use a set instead?
 
-    public List<FXMLController> getControllers() {
-        //XXX see if we could make it unmodifiable here
-        return controllers;
+    // it is important to keep insertion order: the first controller is considered the main one and is kept when closing all secondary stages
+    private final Set<FXMLController> controllers = new LinkedHashSet<>();
+
+    public Collection<FXMLController> getControllers() {
+        return Collections.unmodifiableSet(controllers);
     }
 
     @Nonnull

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLControllerManager.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLControllerManager.java
@@ -45,15 +45,11 @@ public class FXMLControllerManager {
     }
 
     @Nonnull
-    //XXX try to reduce calls, sometimes creating a controller would be strange
     public FXMLController getOrCreateActiveController() {
         FXMLController active = activeController.get();
         if (active == null) {
             active = newController();
             setActiveController(active);
-
-            //XXX see if this call is necessary for its side effects
-            active.setActiveController();
         }
 
         return active;

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLControllerManager.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLControllerManager.java
@@ -29,6 +29,21 @@ public class FXMLControllerManager {
         return Collections.unmodifiableSet(controllers);
     }
 
+    public void register(FXMLController controller, boolean setAsActive) {
+        controllers.add(controller);
+        if (setAsActive) {
+            activeController.set(controller);
+        }
+    }
+
+    public void unregister(FXMLController controller) {
+        controllers.remove(controller);
+    }
+
+    public boolean isRegistered(FXMLController controller) {
+        return controller != null && controllers.contains(controller);
+    }
+
     @Nonnull
     //XXX try to reduce calls, sometimes creating a controller would be strange
     public FXMLController getOrCreateActiveController() {
@@ -53,21 +68,6 @@ public class FXMLControllerManager {
         return activeController;
     }
 
-    public void register(FXMLController controller) {
-        register(controller, false);
-    }
-
-    public void register(FXMLController controller, boolean active) {
-        controllers.add(controller);
-        if (active) {
-            activeController.set(controller);
-        }
-    }
-
-    public void unregister(FXMLController controller) {
-        controllers.remove(controller);
-    }
-
     public void setActiveController(FXMLController controller) {
         //XXX check or add in all controllers list?
         activeController.set(controller);
@@ -81,7 +81,6 @@ public class FXMLControllerManager {
             chart.getController().setActiveChart(chart);
         }
     }
-
 
     public FXMLController newController() {
         return newController(new Stage(StageStyle.DECORATED));

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLControllerManager.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLControllerManager.java
@@ -27,10 +27,11 @@ public class FXMLControllerManager {
     }
 
     @Nonnull
+    //XXX try to reduce calls, sometimes creating a controller would be strange
     public FXMLController getOrCreateActiveController() {
         FXMLController active = activeController.get();
         if (active == null) {
-            active = FXMLController.create();
+            active = newController();
             setActiveController(active);
 
             //XXX see if this call is necessary for its side effects

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/GUIScripter.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/GUIScripter.java
@@ -15,8 +15,6 @@ import org.nmrfx.processor.gui.controls.GridPaneCanvas;
 import org.nmrfx.processor.gui.spectra.DatasetAttributes;
 import org.nmrfx.processor.gui.spectra.KeyBindings;
 import org.nmrfx.processor.gui.spectra.PeakListAttributes;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.concurrent.ExecutionException;
@@ -29,9 +27,6 @@ import java.util.stream.Collectors;
  */
 @PythonAPI("gscript")
 public class GUIScripter {
-
-    private static final Logger log = LoggerFactory.getLogger(GUIScripter.class);
-
     final PolyChart useChart;
     static FXMLController controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
     static Map<String, String> keyActions = new HashMap<>();
@@ -50,7 +45,8 @@ public class GUIScripter {
     }
 
     public static FXMLController getController() {
-        if (controller == null) {
+        // controller may have been closed and unregistered without GUIScripter being notified
+        if (!AnalystApp.getFXMLControllerManager().isRegistered(controller)) {
             controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
         }
         return controller;
@@ -70,34 +66,11 @@ public class GUIScripter {
     }
 
     PolyChart getChart() {
-        PolyChart chart;
-        if (useChart != null) {
-            chart = useChart;
-        } else {
-            if (getActiveController() == null) {
-                try {
-                    FutureTask<Boolean> future = new FutureTask(() -> {
-                        newStage();
-                        return true;
-                    });
-                    ConsoleUtil.runOnFxThread(future);
-                    future.get();
-                } catch (InterruptedException | ExecutionException iE) {
-                    log.warn(iE.getMessage(), iE);
-                }
-            }
-            chart = getActiveController().getActiveChart();
-        }
-        return chart;
+        return useChart != null ? useChart : getActiveController().getActiveChart();
     }
 
     public String active() {
-        PolyChart chart;
-        if (useChart != null) {
-            chart = useChart;
-        } else {
-            chart = PolyChart.getActiveChart();
-        }
+        PolyChart chart = useChart != null ? useChart : PolyChart.getActiveChart();
         return chart.getName();
     }
 

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/GUIScripter.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/GUIScripter.java
@@ -33,7 +33,7 @@ public class GUIScripter {
     private static final Logger log = LoggerFactory.getLogger(GUIScripter.class);
 
     final PolyChart useChart;
-    static FXMLController controller = FXMLController.getActiveController();
+    static FXMLController controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
     static Map<String, String> keyActions = new HashMap<>();
 
     public GUIScripter() {
@@ -46,22 +46,22 @@ public class GUIScripter {
     }
 
     public static void setActiveController() {
-        controller = FXMLController.getActiveController();
+        controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
     }
 
     public static FXMLController getController() {
         if (controller == null) {
-            controller = FXMLController.getActiveController();
+            controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
         }
         return controller;
     }
 
     public static FXMLController getActiveController() {
-        return FXMLController.getActiveController();
+        return AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
     }
 
     public GUIScripter(String chartName) {
-        Optional<PolyChart> chartOpt = FXMLController.getActiveController().getCharts().stream().filter(c -> c.getName().equals(chartName)).findFirst();
+        Optional<PolyChart> chartOpt = AnalystApp.getFXMLControllerManager().getOrCreateActiveController().getCharts().stream().filter(c -> c.getName().equals(chartName)).findFirst();
         if (chartOpt.isPresent()) {
             useChart = chartOpt.get();
         } else {
@@ -508,7 +508,7 @@ public class GUIScripter {
     }
 
     public void newStage() {
-        controller = FXMLController.create();
+        controller = AnalystApp.getFXMLControllerManager().newController();
         PolyChart chartActive = controller.getCharts().get(0);
         controller.setActiveChart(chartActive);
     }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PeakNavigator.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PeakNavigator.java
@@ -2,10 +2,6 @@ package org.nmrfx.processor.gui;
 
 import de.jensd.fx.glyphs.GlyphsDude;
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Consumer;
 import javafx.application.Platform;
 import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableList;
@@ -13,24 +9,24 @@ import javafx.event.ActionEvent;
 import javafx.event.Event;
 import javafx.geometry.Insets;
 import javafx.scene.control.*;
-import javafx.scene.layout.Background;
-import javafx.scene.layout.BackgroundFill;
-import javafx.scene.layout.CornerRadii;
-import javafx.scene.layout.HBox;
-import javafx.scene.layout.Pane;
-import javafx.scene.layout.Priority;
+import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
 import org.nmrfx.analyst.gui.AnalystApp;
 import org.nmrfx.peaks.Peak;
 import org.nmrfx.peaks.PeakDim;
-import org.nmrfx.peaks.events.PeakEvent;
 import org.nmrfx.peaks.PeakList;
+import org.nmrfx.peaks.events.PeakEvent;
 import org.nmrfx.peaks.events.PeakListener;
 import org.nmrfx.processor.gui.spectra.DatasetAttributes;
 import org.nmrfx.processor.gui.spectra.PeakDisplayTool;
 import org.nmrfx.processor.gui.spectra.PeakListAttributes;
 import org.nmrfx.project.ProjectBase;
 import org.nmrfx.utils.GUIUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
 
 /*
  * To change this license header, choose License Headers in Project Properties.
@@ -221,7 +217,7 @@ public class PeakNavigator implements PeakListener {
     public void setPeakList() {
         if (peakList == null) {
             PeakList testList = null;
-            FXMLController controller = FXMLController.getActiveController();
+            FXMLController controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
             PolyChart chart = controller.getActiveChart();
             if (chart != null) {
                 ObservableList<PeakListAttributes> attr = chart.getPeakListAttributes();
@@ -290,7 +286,7 @@ public class PeakNavigator implements PeakListener {
     void updateAtomLabels(Peak peak) {
         if (showAtoms) {
             if (peak != null) {
-                FXMLController controller = FXMLController.getActiveController();
+                FXMLController controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
                 PolyChart chart = controller.getActiveChart();
                 ObservableList<PeakListAttributes> peakAttrs = chart.getPeakListAttributes();
                 ObservableList<DatasetAttributes> dataAttrs = chart.getDatasetAttributes();

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PeakPicking.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PeakPicking.java
@@ -7,6 +7,7 @@ package org.nmrfx.processor.gui;
 
 import javafx.collections.ObservableList;
 import org.controlsfx.dialog.ExceptionDialog;
+import org.nmrfx.analyst.gui.AnalystApp;
 import org.nmrfx.datasets.DatasetBase;
 import org.nmrfx.peaks.InvalidPeakException;
 import org.nmrfx.peaks.Peak;
@@ -236,9 +237,11 @@ public class PeakPicking {
             dialog.showAndWait();
         }
         chart.peakStatus.set(true);
-        if ((peak != null) && FXMLController.getActiveController().isPeakAttrControllerShowing()) {
-            PeakAttrController controller = FXMLController.getActiveController().getPeakAttrController();
-            controller.gotoPeak(peak);
+        if ((peak != null)) {
+            FXMLController controller = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
+            if (controller.isPeakAttrControllerShowing()) {
+                controller.getPeakAttrController().gotoPeak(peak);
+            }
         }
         if ((peak != null) && (singlePickAction != null)) {
             singlePickAction.accept(peak);

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -654,7 +654,7 @@ public class PolyChart extends Region implements PeakListener {
                 peakAttr.selectPeaksInRegion(limits);
                 drawSelectedPeaks(peakAttr);
             }
-            if (controller == FXMLController.getActiveController()) {
+            if (controller == AnalystApp.getFXMLControllerManager().getOrCreateActiveController()) {
                 List<Peak> allSelPeaks = new ArrayList<>();
                 for (PolyChart chart : controller.getCharts()) {
                     allSelPeaks.addAll(chart.getSelectedPeaks());
@@ -772,7 +772,7 @@ public class PolyChart extends Region implements PeakListener {
     }
 
     public void popView() {
-        FXMLController newController = FXMLController.create();
+        FXMLController newController = AnalystApp.getFXMLControllerManager().newController();
         PolyChart newChart = newController.getActiveChart();
         copyTo(newChart);
         newController.getStatusBar().setMode(controller.getStatusBar().getMode());
@@ -1676,7 +1676,7 @@ public class PolyChart extends Region implements PeakListener {
             datasetAttrs.addAll(newAttributes);
         }
         if (!newAttributes.isEmpty()) {
-            FXMLController.getActiveController().updateSpectrumStatusBarOptions(false);
+            AnalystApp.getFXMLControllerManager().getOrCreateActiveController().updateSpectrumStatusBarOptions(false);
             DISDIM newDISDIM = newAttributes.get(0).getDataset().getNDim() == 1 ? DISDIM.OneDX : TwoD;
             // If the display has switched dimensions, full the chart otherwise the axis might be much larger than the current dataset
             fullChart = fullChart || newDISDIM != disDimProp.get();
@@ -3410,7 +3410,7 @@ public class PolyChart extends Region implements PeakListener {
                 }
             }
         }
-        if (controller == FXMLController.getActiveController()) {
+        if (controller == AnalystApp.getFXMLControllerManager().getOrCreateActiveController()) {
             List<Peak> allSelPeaks = new ArrayList<>();
             for (PolyChart chart : controller.getCharts()) {
                 allSelPeaks.addAll(chart.getSelectedPeaks());
@@ -4003,8 +4003,8 @@ public class PolyChart extends Region implements PeakListener {
                     iSlice++;
                 }
                 if ((sliceController == null)
-                        || (!FXMLController.getControllers().contains(sliceController))) {
-                    sliceController = FXMLController.create();
+                        || (!AnalystApp.getFXMLControllerManager().getControllers().contains(sliceController))) {
+                    sliceController = AnalystApp.getFXMLControllerManager().newController();
                 }
                 sliceController.getStage().show();
                 sliceController.getStage().toFront();

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -4002,8 +4002,7 @@ public class PolyChart extends Region implements PeakListener {
                     }
                     iSlice++;
                 }
-                if ((sliceController == null)
-                        || (!AnalystApp.getFXMLControllerManager().getControllers().contains(sliceController))) {
+                if (!AnalystApp.getFXMLControllerManager().isRegistered(sliceController)) {
                     sliceController = AnalystApp.getFXMLControllerManager().newController();
                 }
                 sliceController.getStage().show();

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PreferencesController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PreferencesController.java
@@ -17,29 +17,7 @@
  */
 package org.nmrfx.processor.gui;
 
-import org.nmrfx.analyst.gui.AnalystApp;
-import org.nmrfx.utils.properties.*;
-import org.nmrfx.processor.operations.NESTANMREx;
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.ResourceBundle;
-import java.util.Set;
-import java.util.prefs.Preferences;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.DoubleProperty;
-import javafx.beans.property.IntegerProperty;
-import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.SimpleDoubleProperty;
-import javafx.beans.property.SimpleIntegerProperty;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
+import javafx.beans.property.*;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.event.ActionEvent;
@@ -53,8 +31,18 @@ import javafx.scene.layout.Pane;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import org.controlsfx.control.PropertySheet;
+import org.nmrfx.analyst.gui.AnalystApp;
+import org.nmrfx.processor.operations.NESTANMREx;
+import org.nmrfx.utils.properties.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.prefs.Preferences;
 
 /**
  *
@@ -322,7 +310,7 @@ public class PreferencesController implements Initializable {
             first = Math.max(first, 0);
             Path subPath = path.subpath(first, count);
             MenuItem datasetMenuItem = new MenuItem(subPath.toString());
-            datasetMenuItem.setOnAction(e -> FXMLController.getActiveController().openFile(path.toString(), false, false));
+            datasetMenuItem.setOnAction(e -> AnalystApp.getFXMLControllerManager().getOrCreateActiveController().openFile(path.toString(), false, false));
             recentFileMenuItem.getItems().add(datasetMenuItem);
         }
     }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/spectra/PeakDisplayTool.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/spectra/PeakDisplayTool.java
@@ -1,5 +1,6 @@
 package org.nmrfx.processor.gui.spectra;
 
+import org.nmrfx.analyst.gui.AnalystApp;
 import org.nmrfx.peaks.Peak;
 import org.nmrfx.peaks.PeakDim;
 import org.nmrfx.peaks.PeakList;
@@ -30,12 +31,10 @@ public class PeakDisplayTool {
     }
 
     private static Optional<PolyChart> checkActiveChart(Peak peak) {
-        FXMLController activeController = FXMLController.getActiveController();
-        if (activeController != null) {
-            PolyChart chart = activeController.getActiveChart();
-            if ((chart != null) && (chartHasPeakList(chart, peak.getPeakList()))) {
-                return Optional.of(chart);
-            }
+        FXMLController activeController = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
+        PolyChart chart = activeController.getActiveChart();
+        if ((chart != null) && (chartHasPeakList(chart, peak.getPeakList()))) {
+            return Optional.of(chart);
         }
         return Optional.empty();
     }
@@ -56,10 +55,10 @@ public class PeakDisplayTool {
         if (optChart.isPresent()) {
             return optChart;
         } else {
-            FXMLController activeController = FXMLController.getActiveController();
+            FXMLController activeController = AnalystApp.getFXMLControllerManager().getOrCreateActiveController();
             optChart = checkController(activeController, peak);
             if (optChart.isEmpty()) {
-                for (var controller : FXMLController.getControllers()) {
+                for (var controller : AnalystApp.getFXMLControllerManager().getControllers()) {
                     optChart = checkController(controller, peak);
                     if (optChart.isPresent()) {
                         controller.getStage().toFront();
@@ -157,7 +156,7 @@ public class PeakDisplayTool {
             if ((datasetName != null) && !datasetName.isBlank()) {
                 Dataset dataset = Dataset.getDataset(datasetName);
                 if (dataset != null) {
-                    FXMLController controller  = FXMLController.create();
+                    FXMLController controller = AnalystApp.getFXMLControllerManager().newController();
                     controller.addDataset(dataset, false, false);
                     PolyChart chart = controller.getActiveChart();
                     chart.updatePeakLists(List.of(peakList.getName()));

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/spectra/WindowIO.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/spectra/WindowIO.java
@@ -27,6 +27,7 @@ import javafx.scene.layout.BorderPane;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
+import org.nmrfx.analyst.gui.AnalystApp;
 import org.nmrfx.analyst.gui.python.AnalystPythonInterpreter;
 import org.nmrfx.processor.gui.FXMLController;
 import org.nmrfx.processor.gui.GUIScripter;
@@ -199,7 +200,7 @@ public class WindowIO implements FileWatchListener {
             Path projectDir = ProjectBase.getActive().getDirectory();
             Path path = projectDir.getFileSystem().getPath(projectDir.toString(), "windows", favName + "_fav.yaml");
             try {
-                saveWindow(FXMLController.getActiveController(), path);
+                saveWindow(AnalystApp.getFXMLControllerManager().getOrCreateActiveController(), path);
             } catch (IOException ex) {
                 GUIUtils.warn("Error saving window file", ex.getMessage());
             }
@@ -275,7 +276,7 @@ public class WindowIO implements FileWatchListener {
         int i = 0;
         AnalystPythonInterpreter.exec("import nwyaml\\n");
         FXMLController activeController = GUIScripter.getController();
-        List<FXMLController> controllers = FXMLController.getControllers();
+        List<FXMLController> controllers = AnalystApp.getFXMLControllerManager().getControllers();
         for (FXMLController controller : controllers) {
             GUIScripter.setController(controller);
             String fileName = "stage_" + i + ".yaml";

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/spectra/WindowIO.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/spectra/WindowIO.java
@@ -276,8 +276,7 @@ public class WindowIO implements FileWatchListener {
         int i = 0;
         AnalystPythonInterpreter.exec("import nwyaml\\n");
         FXMLController activeController = GUIScripter.getController();
-        List<FXMLController> controllers = AnalystApp.getFXMLControllerManager().getControllers();
-        for (FXMLController controller : controllers) {
+        for (FXMLController controller : AnalystApp.getFXMLControllerManager().getControllers()) {
             GUIScripter.setController(controller);
             String fileName = "stage_" + i + ".yaml";
             Path path = Paths.get(projectDir.toString(), "windows", fileName);

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/tools/PeakLinker.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/tools/PeakLinker.java
@@ -20,7 +20,6 @@ package org.nmrfx.processor.gui.tools;
 import org.nmrfx.analyst.gui.AnalystApp;
 import org.nmrfx.peaks.Peak;
 import org.nmrfx.peaks.PeakList;
-import org.nmrfx.processor.gui.FXMLController;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,8 +35,7 @@ public class PeakLinker {
 
     public static List<Peak> getSelectedPeaks() {
         List<Peak> allPeaks = new ArrayList<>();
-        List<FXMLController> controllers = AnalystApp.getFXMLControllerManager().getControllers();
-        for (var controller : controllers) {
+        for (var controller : AnalystApp.getFXMLControllerManager().getControllers()) {
             for (var chart : controller.getCharts()) {
                 List<Peak> peaks = chart.getSelectedPeaks();
                 allPeaks.addAll(peaks);

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/tools/PeakLinker.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/tools/PeakLinker.java
@@ -17,11 +17,13 @@
  */
 package org.nmrfx.processor.gui.tools;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.nmrfx.analyst.gui.AnalystApp;
 import org.nmrfx.peaks.Peak;
 import org.nmrfx.peaks.PeakList;
 import org.nmrfx.processor.gui.FXMLController;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  *
@@ -34,7 +36,7 @@ public class PeakLinker {
 
     public static List<Peak> getSelectedPeaks() {
         List<Peak> allPeaks = new ArrayList<>();
-        List<FXMLController> controllers = FXMLController.getControllers();
+        List<FXMLController> controllers = AnalystApp.getFXMLControllerManager().getControllers();
         for (var controller : controllers) {
             for (var chart : controller.getCharts()) {
                 List<Peak> peaks = chart.getSelectedPeaks();
@@ -45,7 +47,7 @@ public class PeakLinker {
     }
 
     public static String getPeakDim(int iDim) {
-        var activeChart = FXMLController.getActiveController().getActiveChart();
+        var activeChart = AnalystApp.getFXMLControllerManager().getOrCreateActiveController().getActiveChart();
         var refList = activeChart.getPeakListAttributes().get(0).getPeakList();
         var refSpectralDim = refList.getSpectralDim(iDim);
         var refDimName = refSpectralDim.getDimName();

--- a/nmrfx-jmx-connector/src/main/java/org/nmrfx/jmx/mbeans/Analyst.java
+++ b/nmrfx-jmx-connector/src/main/java/org/nmrfx/jmx/mbeans/Analyst.java
@@ -20,11 +20,11 @@ package org.nmrfx.jmx.mbeans;
 import javafx.stage.Stage;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
+import org.nmrfx.analyst.gui.AnalystApp;
 import org.nmrfx.jmx.NotificationType;
 import org.nmrfx.processor.datasets.DatasetType;
 import org.nmrfx.processor.events.DatasetSavedEvent;
 import org.nmrfx.processor.gui.ChartProcessor;
-import org.nmrfx.processor.gui.FXMLController;
 import org.nmrfx.processor.gui.controls.ConsoleUtil;
 
 import javax.management.Notification;
@@ -46,7 +46,7 @@ public class Analyst extends NotificationBroadcasterSupport implements AnalystMB
         DatasetType preferredProcessedFormat = DatasetType.typeFromFile(new File(path)).orElse(DatasetType.NMRFX);
 
         ConsoleUtil.runOnFxThread(() -> {
-            FXMLController.getActiveController().openFile(path, false, true, preferredProcessedFormat);
+            AnalystApp.getFXMLControllerManager().getOrCreateActiveController().openFile(path, false, true, preferredProcessedFormat);
             sendNotification(NotificationType.MESSAGE, "File opened", path);
         });
     }
@@ -54,7 +54,7 @@ public class Analyst extends NotificationBroadcasterSupport implements AnalystMB
     @Override
     public void setWindowOnFront() {
         ConsoleUtil.runOnFxThread(() -> {
-            Stage stage = FXMLController.getActiveController().getStage();
+            Stage stage = AnalystApp.getFXMLControllerManager().getOrCreateActiveController().getStage();
             stage.toFront();
             stage.requestFocus();
         });
@@ -65,7 +65,7 @@ public class Analyst extends NotificationBroadcasterSupport implements AnalystMB
         ConsoleUtil.runOnFxThread(() -> {
             // getting the chart processor must be done in fx thread, because otherwise, a client calling
             // open() then generateAutoScript() could try to access the chart processor before its creation.
-            ChartProcessor chartProcessor = FXMLController.getActiveController().getChartProcessor();
+            ChartProcessor chartProcessor = AnalystApp.getFXMLControllerManager().getOrCreateActiveController().getChartProcessor();
             String script = chartProcessor.getGenScript(isPseudo2D);
             chartProcessor.getProcessorController().parseScript(script);
         });


### PR DESCRIPTION
Trying to progressively reduce FXMLController's responsability.

Moving instance management to a separate FXMLControllerManager.
Classes should be renamed, but at a later time since some plugins reference them.

Most file changes are very simple and only update the calling path.
Main changes that need review are in FXMLController & FXMLControllerManager.