### PR TITLE
Nmr 6953 explicit shared canvas

### DIFF
--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
@@ -152,10 +152,6 @@ public class ChartDrawingLayers {
         return base;
     }
 
-    public Canvas getSlicesAndDragBoxes() {
-        return slicesAndDragBoxes;
-    }
-
     public Pane getTop() {
         return top;
     }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
@@ -54,19 +54,25 @@ public class ChartDrawingLayers {
 
 
     public ChartDrawingLayers(FXMLController controller, StackPane stack) {
-        top.setMouseTransparent(true);
-
         grid = new GridPaneCanvas(controller, base);
         grid.addCharts(1, controller.getCharts());
         grid.setMouseTransparent(true);
         grid.setManaged(true);
-
-        base.setManaged(false);
-        peaksAndAnnotations.setManaged(false);
-        slicesAndDragBoxes.setManaged(false);
-        top.setManaged(false);
         grid.widthProperty().addListener(observable -> updateCanvasWidth());
         grid.heightProperty().addListener(observable -> updateCanvasHeight());
+
+        base.setManaged(false);
+        base.setCache(true);
+
+        peaksAndAnnotations.setManaged(false);
+        peaksAndAnnotations.setCache(true);
+        peaksAndAnnotations.setMouseTransparent(true);
+
+        slicesAndDragBoxes.setManaged(false);
+        slicesAndDragBoxes.setMouseTransparent(true);
+
+        top.setManaged(false);
+        top.setMouseTransparent(true);
 
         stack.getChildren().addAll(base, grid, peaksAndAnnotations, slicesAndDragBoxes, top);
     }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
@@ -18,12 +18,16 @@
 package org.nmrfx.processor.gui;
 
 import javafx.scene.Cursor;
+import javafx.scene.Node;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.input.DragEvent;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import org.nmrfx.graphicsio.GraphicsContextProxy;
 import org.nmrfx.processor.gui.controls.GridPaneCanvas;
+import org.nmrfx.processor.gui.spectra.CanvasBindings;
+import org.nmrfx.processor.gui.spectra.DragBindings;
 
 /**
  * Layers on which NMR charts are drawn.
@@ -75,6 +79,17 @@ public class ChartDrawingLayers {
         top.setMouseTransparent(true);
 
         stack.getChildren().addAll(base, grid, peaksAndAnnotations, slicesAndDragBoxes, top);
+        setupEventHandlers(controller);
+    }
+
+    private void setupEventHandlers(FXMLController controller) {
+        CanvasBindings canvasBindings = new CanvasBindings(controller, base);
+        canvasBindings.setHandlers();
+
+        DragBindings dragBindings = new DragBindings(controller, base);
+        base.setOnDragOver(dragBindings::mouseDragOver);
+        base.setOnDragDropped(dragBindings::mouseDragDropped);
+        base.setOnDragExited((DragEvent event) -> base.setStyle("-fx-border-color: #C6C6C6;"));
     }
 
     private void updateCanvasWidth() {
@@ -105,6 +120,10 @@ public class ChartDrawingLayers {
 
     public Cursor getCursor() {
         return base.getCursor();
+    }
+
+    public void requestFocus() {
+        base.requestFocus();
     }
 
     public GraphicsContext getGraphicsContextFor(Item item) {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
@@ -36,7 +36,10 @@ import org.nmrfx.processor.gui.spectra.DragBindings;
 public class ChartDrawingLayers {
     enum Item {
         Spectrum,
-        Peaks
+        Peaks,
+        Annotations,
+        Slices,
+        DragBoxes,
     }
 
     // Manages grid layout when displaying multiple charts on the same drawing canvas
@@ -129,7 +132,8 @@ public class ChartDrawingLayers {
     public GraphicsContext getGraphicsContextFor(Item item) {
         Canvas canvas =  switch (item) {
             case Spectrum -> base;
-            case Peaks -> peaksAndAnnotations;
+            case Peaks, Annotations -> peaksAndAnnotations;
+            case Slices, DragBoxes -> slicesAndDragBoxes;
         };
 
         return canvas.getGraphicsContext2D();
@@ -146,10 +150,6 @@ public class ChartDrawingLayers {
 
     public Canvas getBase() {
         return base;
-    }
-
-    public Canvas getPeaksAndAnnotations() {
-        return peaksAndAnnotations;
     }
 
     public Canvas getSlicesAndDragBoxes() {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
@@ -17,6 +17,7 @@
  */
 package org.nmrfx.processor.gui;
 
+import javafx.scene.Cursor;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.layout.Pane;
@@ -82,6 +83,22 @@ public class ChartDrawingLayers {
         base.setHeight(height);
         peaksAndAnnotations.setHeight(height);
         slicesAndDragBoxes.setHeight(height);
+    }
+
+    public double getWidth() {
+        return base.getWidth();
+    }
+
+    public double getHeight() {
+        return base.getHeight();
+    }
+
+    public void setCursor(Cursor value) {
+        base.setCursor(value);
+    }
+
+    public Cursor getCursor() {
+        return base.getCursor();
     }
 
     public GraphicsContext getGraphicsContextFor(Item item) {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
@@ -1,3 +1,20 @@
+/*
+ * NMRFx Processor : A Program for Processing NMR Data
+ * Copyright (C) 2004-2023 One Moon Scientific, Inc., Westfield, N.J., USA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.nmrfx.processor.gui;
 
 import javafx.scene.canvas.Canvas;
@@ -5,15 +22,26 @@ import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import org.nmrfx.processor.gui.controls.GridPaneCanvas;
 
+/**
+ * Layers on which NMR charts are drawn.
+ * These layers can be shared across multiple charts, which will have to draw at the correct coordinated by themselves using the layout information.
+ */
 public class ChartDrawingLayers {
-    // passed to chart: plotcontent, canvas, peakCanvas, annoCanvals
-    // added to chartPane: canvas, chartGroup, peakCancas, annoCanvas, plotContent
-    // difference: chartGroup, which is the gridpane
-
+    // Manages grid layout when displaying multiple charts on the same drawing canvas
+    // Also contains chart instances (as javafx Region objects)
     private final GridPaneCanvas chartGroup;
+
+    // Base layer (background): contains the spectra, axes, ...
     private final Canvas canvas = new Canvas();
+
+    // Second layer: contains peaks and annotations
     private final Canvas peakCanvas = new Canvas();
+
+    // Third layer: contains slices and drag-boxes
     private final Canvas annoCanvas = new Canvas();
+
+    // Top level (foreground): contains crosshairs, highlighted regions, selected canvas handles
+    // Equivalent to a glasspane in swing
     private final Pane plotContent = new Pane();
 
 

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
@@ -29,72 +29,72 @@ import org.nmrfx.processor.gui.controls.GridPaneCanvas;
 public class ChartDrawingLayers {
     // Manages grid layout when displaying multiple charts on the same drawing canvas
     // Also contains chart instances (as javafx Region objects)
-    private final GridPaneCanvas chartGroup;
+    private final GridPaneCanvas grid;
 
     // Base layer (background): contains the spectra, axes, ...
-    private final Canvas canvas = new Canvas();
+    private final Canvas base = new Canvas();
 
     // Second layer: contains peaks and annotations
-    private final Canvas peakCanvas = new Canvas();
+    private final Canvas peaksAndAnnotations = new Canvas();
 
     // Third layer: contains slices and drag-boxes
-    private final Canvas annoCanvas = new Canvas();
+    private final Canvas slicesAndDragBoxes = new Canvas();
 
     // Top level (foreground): contains crosshairs, highlighted regions, selected canvas handles
     // Equivalent to a glasspane in swing
-    private final Pane plotContent = new Pane();
+    private final Pane top = new Pane();
 
 
     public ChartDrawingLayers(FXMLController controller, StackPane stack) {
-        plotContent.setMouseTransparent(true);
+        top.setMouseTransparent(true);
 
-        chartGroup = new GridPaneCanvas(controller, canvas);
-        chartGroup.addCharts(1, controller.getCharts());
-        chartGroup.setMouseTransparent(true);
-        chartGroup.setManaged(true);
+        grid = new GridPaneCanvas(controller, base);
+        grid.addCharts(1, controller.getCharts());
+        grid.setMouseTransparent(true);
+        grid.setManaged(true);
 
-        canvas.setManaged(false);
-        peakCanvas.setManaged(false);
-        annoCanvas.setManaged(false);
-        plotContent.setManaged(false);
-        chartGroup.widthProperty().addListener(observable -> updateCanvasWidth());
-        chartGroup.heightProperty().addListener(observable -> updateCanvasHeight());
+        base.setManaged(false);
+        peaksAndAnnotations.setManaged(false);
+        slicesAndDragBoxes.setManaged(false);
+        top.setManaged(false);
+        grid.widthProperty().addListener(observable -> updateCanvasWidth());
+        grid.heightProperty().addListener(observable -> updateCanvasHeight());
 
-        stack.getChildren().addAll(canvas, chartGroup, peakCanvas, annoCanvas, plotContent);
+        stack.getChildren().addAll(base, grid, peaksAndAnnotations, slicesAndDragBoxes, top);
     }
 
     private void updateCanvasWidth() {
-        double width = chartGroup.getWidth();
-        canvas.setWidth(width);
-        peakCanvas.setWidth(width);
-        annoCanvas.setWidth(width);
+        double width = grid.getWidth();
+        base.setWidth(width);
+        peaksAndAnnotations.setWidth(width);
+        slicesAndDragBoxes.setWidth(width);
     }
 
     private void updateCanvasHeight() {
-        double height = chartGroup.getHeight();
-        canvas.setHeight(height);
-        peakCanvas.setHeight(height);
-        annoCanvas.setHeight(height);
+        double height = grid.getHeight();
+        base.setHeight(height);
+        peaksAndAnnotations.setHeight(height);
+        slicesAndDragBoxes.setHeight(height);
     }
 
     //XXX try to remove accessor usages from FXMLController
-    public GridPaneCanvas getChartGroup() {
-        return chartGroup;
+    public GridPaneCanvas getGrid() {
+        return grid;
     }
 
-    public Canvas getCanvas() {
-        return canvas;
+    public Canvas getBase() {
+        return base;
     }
 
-    public Canvas getPeakCanvas() {
-        return peakCanvas;
+    public Canvas getPeaksAndAnnotations() {
+        return peaksAndAnnotations;
     }
 
-    public Canvas getAnnoCanvas() {
-        return annoCanvas;
+    public Canvas getSlicesAndDragBoxes() {
+        return slicesAndDragBoxes;
     }
 
-    public Pane getPlotContent() {
-        return plotContent;
+    public Pane getTop() {
+        return top;
     }
 }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
@@ -1,0 +1,72 @@
+package org.nmrfx.processor.gui;
+
+import javafx.scene.canvas.Canvas;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.StackPane;
+import org.nmrfx.processor.gui.controls.GridPaneCanvas;
+
+public class ChartDrawingLayers {
+    // passed to chart: plotcontent, canvas, peakCanvas, annoCanvals
+    // added to chartPane: canvas, chartGroup, peakCancas, annoCanvas, plotContent
+    // difference: chartGroup, which is the gridpane
+
+    private final GridPaneCanvas chartGroup;
+    private final Canvas canvas = new Canvas();
+    private final Canvas peakCanvas = new Canvas();
+    private final Canvas annoCanvas = new Canvas();
+    private final Pane plotContent = new Pane();
+
+
+    public ChartDrawingLayers(FXMLController controller, StackPane stack) {
+        plotContent.setMouseTransparent(true);
+
+        chartGroup = new GridPaneCanvas(controller, canvas);
+        chartGroup.addCharts(1, controller.getCharts());
+        chartGroup.setMouseTransparent(true);
+        chartGroup.setManaged(true);
+
+        canvas.setManaged(false);
+        peakCanvas.setManaged(false);
+        annoCanvas.setManaged(false);
+        plotContent.setManaged(false);
+        chartGroup.widthProperty().addListener(observable -> updateCanvasWidth());
+        chartGroup.heightProperty().addListener(observable -> updateCanvasHeight());
+
+        stack.getChildren().addAll(canvas, chartGroup, peakCanvas, annoCanvas, plotContent);
+    }
+
+    private void updateCanvasWidth() {
+        double width = chartGroup.getWidth();
+        canvas.setWidth(width);
+        peakCanvas.setWidth(width);
+        annoCanvas.setWidth(width);
+    }
+
+    private void updateCanvasHeight() {
+        double height = chartGroup.getHeight();
+        canvas.setHeight(height);
+        peakCanvas.setHeight(height);
+        annoCanvas.setHeight(height);
+    }
+
+    //XXX try to remove accessor usages from FXMLController
+    public GridPaneCanvas getChartGroup() {
+        return chartGroup;
+    }
+
+    public Canvas getCanvas() {
+        return canvas;
+    }
+
+    public Canvas getPeakCanvas() {
+        return peakCanvas;
+    }
+
+    public Canvas getAnnoCanvas() {
+        return annoCanvas;
+    }
+
+    public Pane getPlotContent() {
+        return plotContent;
+    }
+}

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
@@ -18,8 +18,10 @@
 package org.nmrfx.processor.gui;
 
 import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
+import org.nmrfx.graphicsio.GraphicsContextProxy;
 import org.nmrfx.processor.gui.controls.GridPaneCanvas;
 
 /**
@@ -27,6 +29,11 @@ import org.nmrfx.processor.gui.controls.GridPaneCanvas;
  * These layers can be shared across multiple charts, which will have to draw at the correct coordinated by themselves using the layout information.
  */
 public class ChartDrawingLayers {
+    enum Item {
+        Spectrum,
+        Peaks
+    }
+
     // Manages grid layout when displaying multiple charts on the same drawing canvas
     // Also contains chart instances (as javafx Region objects)
     private final GridPaneCanvas grid;
@@ -75,6 +82,19 @@ public class ChartDrawingLayers {
         base.setHeight(height);
         peaksAndAnnotations.setHeight(height);
         slicesAndDragBoxes.setHeight(height);
+    }
+
+    public GraphicsContext getGraphicsContextFor(Item item) {
+        Canvas canvas =  switch (item) {
+            case Spectrum -> base;
+            case Peaks -> peaksAndAnnotations;
+        };
+
+        return canvas.getGraphicsContext2D();
+    }
+
+    public GraphicsContextProxy getGraphicsProxyFor(Item item) {
+        return new GraphicsContextProxy(getGraphicsContextFor(item));
     }
 
     //XXX try to remove accessor usages from FXMLController

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -834,9 +834,7 @@ public class FXMLController implements Initializable, StageBasedController, Publ
             topBar.getChildren().add(0, menuBar);
         }
         chartDrawingLayers = new ChartDrawingLayers(this, chartPane);
-        activeChart = PolyChartManager.getInstance().create(this,
-                chartDrawingLayers.getPlotContent(), chartDrawingLayers.getCanvas(),
-                chartDrawingLayers.getPeakCanvas(), chartDrawingLayers.getAnnoCanvas());
+        activeChart = PolyChartManager.getInstance().create(this, chartDrawingLayers);
         new CanvasBindings(this, chartDrawingLayers.getCanvas()).setHandlers();
         initToolBar(toolBar);
         charts.add(activeChart);
@@ -1069,7 +1067,7 @@ public class FXMLController implements Initializable, StageBasedController, Publ
     }
 
     public void addChart() {
-        PolyChart chart = PolyChartManager.getInstance().create(this, chartDrawingLayers.getPlotContent(), chartDrawingLayers.getCanvas(), chartDrawingLayers.getPeakCanvas(), chartDrawingLayers.getAnnoCanvas());
+        PolyChart chart = PolyChartManager.getInstance().create(this, chartDrawingLayers);
         charts.add(chart);
         chart.setChartDisabled(true);
         chartDrawingLayers.getChartGroup().addChart(chart);

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -677,12 +677,12 @@ public class FXMLController implements Initializable, StageBasedController, Publ
         File selectedFile = fileChooser.showSaveDialog(null);
         if (selectedFile != null) {
             try {
-                chartDrawingLayers.getPlotContent().setVisible(false);
+                chartDrawingLayers.getTop().setVisible(false);
                 GUIUtils.snapNode(chartPane, selectedFile);
             } catch (IOException ex) {
                 GUIUtils.warn("Error saving png file", ex.getLocalizedMessage());
             } finally {
-                chartDrawingLayers.getPlotContent().setVisible(true);
+                chartDrawingLayers.getTop().setVisible(true);
             }
         }
     }
@@ -709,7 +709,7 @@ public class FXMLController implements Initializable, StageBasedController, Publ
         if (fileName != null) {
             try {
                 PDFGraphicsContext pdfGC = new PDFGraphicsContext();
-                pdfGC.create(true, chartDrawingLayers.getCanvas().getWidth(), chartDrawingLayers.getCanvas().getHeight(), fileName);
+                pdfGC.create(true, chartDrawingLayers.getBase().getWidth(), chartDrawingLayers.getBase().getHeight(), fileName);
                 for (PolyChart chart : charts) {
                     chart.exportVectorGraphics(pdfGC);
                 }
@@ -743,7 +743,7 @@ public class FXMLController implements Initializable, StageBasedController, Publ
         if (fileName != null) {
             SVGGraphicsContext svgGC = new SVGGraphicsContext();
             try {
-                svgGC.create(chartDrawingLayers.getCanvas().getWidth(), chartDrawingLayers.getCanvas().getHeight(), fileName);
+                svgGC.create(chartDrawingLayers.getBase().getWidth(), chartDrawingLayers.getBase().getHeight(), fileName);
                 for (PolyChart chart : charts) {
                     chart.exportVectorGraphics(svgGC);
                 }
@@ -760,7 +760,7 @@ public class FXMLController implements Initializable, StageBasedController, Publ
         SVGGraphicsContext svgGC = new SVGGraphicsContext();
         try {
             ByteArrayOutputStream stream = new ByteArrayOutputStream();
-            svgGC.create(chartDrawingLayers.getCanvas().getWidth(), chartDrawingLayers.getCanvas().getHeight(), stream);
+            svgGC.create(chartDrawingLayers.getBase().getWidth(), chartDrawingLayers.getBase().getHeight(), stream);
             for (PolyChart chart : charts) {
                 chart.exportVectorGraphics(svgGC);
             }
@@ -835,7 +835,7 @@ public class FXMLController implements Initializable, StageBasedController, Publ
         }
         chartDrawingLayers = new ChartDrawingLayers(this, chartPane);
         activeChart = PolyChartManager.getInstance().create(this, chartDrawingLayers);
-        new CanvasBindings(this, chartDrawingLayers.getCanvas()).setHandlers();
+        new CanvasBindings(this, chartDrawingLayers.getBase()).setHandlers();
         initToolBar(toolBar);
         charts.add(activeChart);
 
@@ -843,7 +843,7 @@ public class FXMLController implements Initializable, StageBasedController, Publ
             if (arg2.getWidth() < 1.0 || arg2.getHeight() < 1.0) {
                 return;
             }
-            chartDrawingLayers.getChartGroup().requestLayout();
+            chartDrawingLayers.getGrid().requestLayout();
         });
 
         statusBar.setMode(1);
@@ -884,16 +884,16 @@ public class FXMLController implements Initializable, StageBasedController, Publ
     }
 
     public Cursor getCurrentCursor() {
-        return chartDrawingLayers.getCanvas().getCursor();
+        return chartDrawingLayers.getBase().getCursor();
     }
 
     public void setCurrentCursor(Cursor cursor) {
-        chartDrawingLayers.getCanvas().setCursor(cursor);
+        chartDrawingLayers.getBase().setCursor(cursor);
     }
 
     public void setCursor() {
         Cursor cursor = cursorProperty.getValue();
-        chartDrawingLayers.getCanvas().setCursor(cursor);
+        chartDrawingLayers.getBase().setCursor(cursor);
         for (PolyChart chart : charts) {
             chart.getCrossHairs().setAllStates(CanvasCursor.isCrosshair(cursor));
         }
@@ -1003,7 +1003,7 @@ public class FXMLController implements Initializable, StageBasedController, Publ
 
     public void removeChart(PolyChart chart) {
         if (chart != null) {
-            chartDrawingLayers.getChartGroup().getChildren().remove(chart);
+            chartDrawingLayers.getGrid().getChildren().remove(chart);
             charts.remove(chart);
             if (chart == activeChart) {
                 if (charts.isEmpty()) {
@@ -1012,7 +1012,7 @@ public class FXMLController implements Initializable, StageBasedController, Publ
                     activeChart = charts.get(0);
                 }
             }
-            chartDrawingLayers.getChartGroup().requestLayout();
+            chartDrawingLayers.getGrid().requestLayout();
             for (PolyChart refreshChart : charts) {
                 refreshChart.layoutPlotChildren();
             }
@@ -1054,30 +1054,30 @@ public class FXMLController implements Initializable, StageBasedController, Publ
                 addChart();
             }
         }
-        chartDrawingLayers.getChartGroup().addCharts(chartDrawingLayers.getChartGroup().getRows(), charts);
+        chartDrawingLayers.getGrid().addCharts(chartDrawingLayers.getGrid().getRows(), charts);
     }
 
     public void arrange(int nRows) {
-        chartDrawingLayers.getChartGroup().setRows(nRows);
-        chartDrawingLayers.getChartGroup().calculateAndSetOrientation();
+        chartDrawingLayers.getGrid().setRows(nRows);
+        chartDrawingLayers.getGrid().calculateAndSetOrientation();
     }
 
     public void draw() {
-        chartDrawingLayers.getChartGroup().layoutChildren();
+        chartDrawingLayers.getGrid().layoutChildren();
     }
 
     public void addChart() {
         PolyChart chart = PolyChartManager.getInstance().create(this, chartDrawingLayers);
         charts.add(chart);
         chart.setChartDisabled(true);
-        chartDrawingLayers.getChartGroup().addChart(chart);
+        chartDrawingLayers.getGrid().addChart(chart);
         activeChart = chart;
     }
 
     public void setBorderState(boolean state) {
         minBorders.set(state);
-        chartDrawingLayers.getChartGroup().updateConstraints();
-        chartDrawingLayers.getChartGroup().layoutChildren();
+        chartDrawingLayers.getGrid().updateConstraints();
+        chartDrawingLayers.getGrid().layoutChildren();
     }
 
     public double[][] prepareChildren(int nRows, int nCols) {
@@ -1189,7 +1189,7 @@ public class FXMLController implements Initializable, StageBasedController, Publ
     public void removeSelectedChart() {
         if (charts.size() > 1) {
             getActiveChart().close();
-            arrange(chartDrawingLayers.getChartGroup().getOrientation());
+            arrange(chartDrawingLayers.getGrid().getOrientation());
         }
     }
 
@@ -1206,7 +1206,7 @@ public class FXMLController implements Initializable, StageBasedController, Publ
                 List<DatasetAttributes> current = new ArrayList<>(datasetAttrs);
                 setNCharts(current.size());
                 chart.getDatasetAttributes().clear();
-                chartDrawingLayers.getChartGroup().setOrientation(orient, true);
+                chartDrawingLayers.getGrid().setOrientation(orient, true);
                 for (int i = 0; i < charts.size(); i++) {
                     DatasetAttributes datasetAttr = current.get(i);
                     PolyChart iChart = charts.get(i);
@@ -1224,22 +1224,22 @@ public class FXMLController implements Initializable, StageBasedController, Publ
                     iChart.getCrossHairs().setAllStates(true);
                 }
                 setChartDisable(false);
-                chartDrawingLayers.getChartGroup().layoutChildren();
+                chartDrawingLayers.getGrid().layoutChildren();
                 charts.forEach(PolyChart::refresh);
                 return;
             }
         }
-        chartDrawingLayers.getChartGroup().setOrientation(orient, true);
+        chartDrawingLayers.getGrid().setOrientation(orient, true);
         setChartDisable(false);
-        chartDrawingLayers.getChartGroup().layoutChildren();
+        chartDrawingLayers.getGrid().layoutChildren();
     }
 
     public int arrangeGetRows() {
-        return chartDrawingLayers.getChartGroup().getRows();
+        return chartDrawingLayers.getGrid().getRows();
     }
 
     public int arrangeGetColumns() {
-        return chartDrawingLayers.getChartGroup().getColumns();
+        return chartDrawingLayers.getGrid().getColumns();
     }
 
     public void alignCenters() {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -709,7 +709,7 @@ public class FXMLController implements Initializable, StageBasedController, Publ
         if (fileName != null) {
             try {
                 PDFGraphicsContext pdfGC = new PDFGraphicsContext();
-                pdfGC.create(true, chartDrawingLayers.getBase().getWidth(), chartDrawingLayers.getBase().getHeight(), fileName);
+                pdfGC.create(true, chartDrawingLayers.getWidth(), chartDrawingLayers.getHeight(), fileName);
                 for (PolyChart chart : charts) {
                     chart.exportVectorGraphics(pdfGC);
                 }
@@ -743,7 +743,7 @@ public class FXMLController implements Initializable, StageBasedController, Publ
         if (fileName != null) {
             SVGGraphicsContext svgGC = new SVGGraphicsContext();
             try {
-                svgGC.create(chartDrawingLayers.getBase().getWidth(), chartDrawingLayers.getBase().getHeight(), fileName);
+                svgGC.create(chartDrawingLayers.getWidth(), chartDrawingLayers.getHeight(), fileName);
                 for (PolyChart chart : charts) {
                     chart.exportVectorGraphics(svgGC);
                 }
@@ -760,7 +760,7 @@ public class FXMLController implements Initializable, StageBasedController, Publ
         SVGGraphicsContext svgGC = new SVGGraphicsContext();
         try {
             ByteArrayOutputStream stream = new ByteArrayOutputStream();
-            svgGC.create(chartDrawingLayers.getBase().getWidth(), chartDrawingLayers.getBase().getHeight(), stream);
+            svgGC.create(chartDrawingLayers.getWidth(), chartDrawingLayers.getHeight(), stream);
             for (PolyChart chart : charts) {
                 chart.exportVectorGraphics(svgGC);
             }
@@ -884,16 +884,16 @@ public class FXMLController implements Initializable, StageBasedController, Publ
     }
 
     public Cursor getCurrentCursor() {
-        return chartDrawingLayers.getBase().getCursor();
+        return chartDrawingLayers.getCursor();
     }
 
     public void setCurrentCursor(Cursor cursor) {
-        chartDrawingLayers.getBase().setCursor(cursor);
+        chartDrawingLayers.setCursor(cursor);
     }
 
     public void setCursor() {
         Cursor cursor = cursorProperty.getValue();
-        chartDrawingLayers.getBase().setCursor(cursor);
+        chartDrawingLayers.setCursor(cursor);
         for (PolyChart chart : charts) {
             chart.getCrossHairs().setAllStates(CanvasCursor.isCrosshair(cursor));
         }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -835,7 +835,6 @@ public class FXMLController implements Initializable, StageBasedController, Publ
         }
         chartDrawingLayers = new ChartDrawingLayers(this, chartPane);
         activeChart = PolyChartManager.getInstance().create(this, chartDrawingLayers);
-        new CanvasBindings(this, chartDrawingLayers.getBase()).setHandlers();
         initToolBar(toolBar);
         charts.add(activeChart);
 

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -148,7 +148,6 @@ public class PolyChart extends Region implements PeakListener {
     private KeyBindings keyBindings;
     private MouseBindings mouseBindings;
     private GestureBindings gestureBindings;
-    private DragBindings dragBindings;
     private CrossHairs crossHairs;
 
     protected PolyChart(FXMLController controller, String name, ChartDrawingLayers drawingLayers) {
@@ -284,13 +283,11 @@ public class PolyChart extends Region implements PeakListener {
         keyBindings = new KeyBindings(this);
         mouseBindings = new MouseBindings(this);
         gestureBindings = new GestureBindings(this);
-        dragBindings = new DragBindings(controller, drawingLayers.getBase());
         specMenu = new SpectrumMenu(this);
         peakMenu = new PeakMenu(this);
         regionMenu = new RegionMenu(this);
         integralMenu = new IntegralMenu(this);
-        setDragHandlers(drawingLayers.getBase());
-        drawingLayers.getBase().requestFocus();
+        drawingLayers.requestFocus();
     }
 
 
@@ -358,12 +355,6 @@ public class PolyChart extends Region implements PeakListener {
 
     public ChartMenu getRegionMenu() {
         return regionMenu;
-    }
-
-    private void setDragHandlers(Node mouseNode) {
-        mouseNode.setOnDragOver((DragEvent event) -> dragBindings.mouseDragOver(event));
-        mouseNode.setOnDragDropped((DragEvent event) -> dragBindings.mouseDragDropped(event));
-        mouseNode.setOnDragExited((DragEvent event) -> mouseNode.setStyle("-fx-border-color: #C6C6C6;"));
     }
 
     public SliceAttributes getSliceAttributes() {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -277,7 +277,6 @@ public class PolyChart extends Region implements PeakListener {
         drawingLayers.getTop().getChildren().add(highlightRect);
         canvasHandles.forEach(handle -> handle.visibleProperty().bind(chartSelected));
         drawingLayers.getTop().getChildren().addAll(canvasHandles);
-        loadData();
         axes.init(this);
         drawingLayers.setCursor(CanvasCursor.SELECTOR.getCursor());
         MapChangeListener<String, PeakList> mapChangeListener = change -> purgeInvalidPeakListAttributes();
@@ -3515,14 +3514,6 @@ public class PolyChart extends Region implements PeakListener {
 
     public double getPivotFraction() {
         return phaseFraction;
-    }
-
-    protected void loadData() {
-        //XXX move to ChartDrawingLayers
-        drawingLayers.getBase().setCache(true);
-        drawingLayers.getPeaksAndAnnotations().setCache(true);
-        drawingLayers.getPeaksAndAnnotations().setMouseTransparent(true);
-        drawingLayers.getSlicesAndDragBoxes().setMouseTransparent(true);
     }
 
     public void setSliceStatus(boolean state) {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -155,11 +155,11 @@ public class PolyChart extends Region implements PeakListener {
         this.controller = controller;
         this.name = name;
         this.drawingLayers = drawingLayers;
-        drawSpectrum = new DrawSpectrum(axes, drawingLayers.getBase());
+        drawSpectrum = new DrawSpectrum(axes, drawingLayers.getGraphicsProxyFor(ChartDrawingLayers.Item.Spectrum));
         drawSpectrum.setupHaltButton(controller.getHaltButton());
 
         initChart();
-        drawPeaks = new DrawPeaks(this, drawingLayers.getPeaksAndAnnotations());
+        drawPeaks = new DrawPeaks(this, drawingLayers.getGraphicsContextFor(ChartDrawingLayers.Item.Peaks));
         setVisible(false);
     }
 

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -1891,8 +1891,6 @@ public class PolyChart extends Region implements PeakListener {
                 gC.strokeLine(xPos + width - borders.getRight(), yPos + borders.getTop(), xPos + width - borders.getRight(), yPos + height - borders.getBottom());
             }
 
-            drawingLayers.getPeaksAndAnnotations().setWidth(drawingLayers.getWidth());
-            drawingLayers.getPeaksAndAnnotations().setHeight(drawingLayers.getHeight());
             GraphicsContext peakGC = drawingLayers.getPeaksAndAnnotations().getGraphicsContext2D();
             peakGC.clearRect(xPos, yPos, width, height);
             gC.beginPath();
@@ -2901,9 +2899,6 @@ public class PolyChart extends Region implements PeakListener {
         double width = getWidth();
         double height = getHeight();
         if (drawingLayers.getPeaksAndAnnotations() != null) {
-            //XXX why? they should already hav ethe same size, they are bound together
-            drawingLayers.getPeaksAndAnnotations().setWidth(drawingLayers.getWidth());
-            drawingLayers.getPeaksAndAnnotations().setHeight(drawingLayers.getHeight());
             try {
                 if (peakGC instanceof GraphicsContextProxy) {
                     peakGC.clearRect(xPos, yPos, width, height);

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -279,7 +279,7 @@ public class PolyChart extends Region implements PeakListener {
         drawingLayers.getTop().getChildren().addAll(canvasHandles);
         loadData();
         axes.init(this);
-        drawingLayers.getBase().setCursor(CanvasCursor.SELECTOR.getCursor());
+        drawingLayers.setCursor(CanvasCursor.SELECTOR.getCursor());
         MapChangeListener<String, PeakList> mapChangeListener = change -> purgeInvalidPeakListAttributes();
         ProjectBase.getActive().addPeakListListener(mapChangeListener);
         keyBindings = new KeyBindings(this);
@@ -326,7 +326,7 @@ public class PolyChart extends Region implements PeakListener {
     }
 
     public Cursor getCanvasCursor() {
-        return drawingLayers.getBase().getCursor();
+        return drawingLayers.getCursor();
     }
 
     public boolean contains(double x, double y) {
@@ -1818,9 +1818,8 @@ public class PolyChart extends Region implements PeakListener {
             return;
         }
         useImmediateMode = false;
-        GraphicsContext gCC = drawingLayers.getBase().getGraphicsContext2D();
-        GraphicsContextInterface gC = new GraphicsContextProxy(gCC);
-        GraphicsContextInterface gCPeaks = new GraphicsContextProxy(drawingLayers.getPeaksAndAnnotations().getGraphicsContext2D());
+        GraphicsContextInterface gC = drawingLayers.getGraphicsProxyFor(ChartDrawingLayers.Item.Spectrum);
+        GraphicsContextInterface gCPeaks = drawingLayers.getGraphicsProxyFor(ChartDrawingLayers.Item.Peaks);
         if (is1D()) {
             axes.setYAxisByLevel();
         }
@@ -1902,8 +1901,8 @@ public class PolyChart extends Region implements PeakListener {
                 gC.strokeLine(xPos + width - borders.getRight(), yPos + borders.getTop(), xPos + width - borders.getRight(), yPos + height - borders.getBottom());
             }
 
-            drawingLayers.getPeaksAndAnnotations().setWidth(drawingLayers.getBase().getWidth());
-            drawingLayers.getPeaksAndAnnotations().setHeight(drawingLayers.getBase().getHeight());
+            drawingLayers.getPeaksAndAnnotations().setWidth(drawingLayers.getWidth());
+            drawingLayers.getPeaksAndAnnotations().setHeight(drawingLayers.getHeight());
             GraphicsContext peakGC = drawingLayers.getPeaksAndAnnotations().getGraphicsContext2D();
             peakGC.clearRect(xPos, yPos, width, height);
             gC.beginPath();
@@ -2912,8 +2911,9 @@ public class PolyChart extends Region implements PeakListener {
         double width = getWidth();
         double height = getHeight();
         if (drawingLayers.getPeaksAndAnnotations() != null) {
-            drawingLayers.getPeaksAndAnnotations().setWidth(drawingLayers.getBase().getWidth());
-            drawingLayers.getPeaksAndAnnotations().setHeight(drawingLayers.getBase().getHeight());
+            //XXX why? they should already hav ethe same size, they are bound together
+            drawingLayers.getPeaksAndAnnotations().setWidth(drawingLayers.getWidth());
+            drawingLayers.getPeaksAndAnnotations().setHeight(drawingLayers.getHeight());
             try {
                 if (peakGC instanceof GraphicsContextProxy) {
                     peakGC.clearRect(xPos, yPos, width, height);
@@ -3518,6 +3518,7 @@ public class PolyChart extends Region implements PeakListener {
     }
 
     protected void loadData() {
+        //XXX move to ChartDrawingLayers
         drawingLayers.getBase().setCache(true);
         drawingLayers.getPeaksAndAnnotations().setCache(true);
         drawingLayers.getPeaksAndAnnotations().setMouseTransparent(true);
@@ -3533,8 +3534,8 @@ public class PolyChart extends Region implements PeakListener {
         double yPos = getLayoutY();
         double width = getWidth();
         double height = getHeight();
-        drawingLayers.getSlicesAndDragBoxes().setWidth(drawingLayers.getBase().getWidth());
-        drawingLayers.getSlicesAndDragBoxes().setHeight(drawingLayers.getBase().getHeight());
+        drawingLayers.getSlicesAndDragBoxes().setWidth(drawingLayers.getWidth());
+        drawingLayers.getSlicesAndDragBoxes().setHeight(drawingLayers.getHeight());
         GraphicsContext annoGC = drawingLayers.getSlicesAndDragBoxes().getGraphicsContext2D();
         GraphicsContextInterface gC = new GraphicsContextProxy(annoGC);
         gC.clearRect(xPos, yPos, width, height);

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -392,19 +392,19 @@ public class PolyChart extends Region implements PeakListener {
     public void dragBox(MOUSE_ACTION mouseAction, double[] dragStart, double x, double y) {
         int dragTol = 4;
         if ((Math.abs(x - dragStart[0]) > dragTol) || (Math.abs(y - dragStart[1]) > dragTol)) {
-            GraphicsContext annoGC = drawingLayers.getSlicesAndDragBoxes().getGraphicsContext2D();
-            double annoWidth = drawingLayers.getSlicesAndDragBoxes().getWidth();
-            double annoHeight = drawingLayers.getSlicesAndDragBoxes().getHeight();
-            annoGC.clearRect(0, 0, annoWidth, annoHeight);
+            GraphicsContext gc = drawingLayers.getGraphicsContextFor(ChartDrawingLayers.Item.DragBoxes);
+            double annoWidth = drawingLayers.getWidth();
+            double annoHeight = drawingLayers.getHeight();
+            gc.clearRect(0, 0, annoWidth, annoHeight);
             double dX = Math.abs(x - dragStart[0]);
             double dY = Math.abs(y - dragStart[1]);
             double startX = Math.min(x, dragStart[0]);
             double startY = Math.min(y, dragStart[1]);
             double yPos = getLayoutY();
-            annoGC.setLineDashes(null);
+            gc.setLineDashes(null);
             if (mouseAction == MOUSE_ACTION.DRAG_EXPAND || mouseAction == MOUSE_ACTION.DRAG_ADDREGION || mouseAction == MOUSE_ACTION.DRAG_PEAKPICK) {
                 if ((dX < MIN_MOVE) || (!is1D() && (dY < MIN_MOVE))) {
-                    annoGC.setLineDashes(5);
+                    gc.setLineDashes(5);
                 }
             }
             Color color;
@@ -417,20 +417,20 @@ public class PolyChart extends Region implements PeakListener {
                     default -> Color.DARKORANGE;
                 };
             }
-            annoGC.setStroke(color);
+            gc.setStroke(color);
             if (is1D()) {
                 if (mouseAction == MOUSE_ACTION.DRAG_PEAKPICK) {
-                    annoGC.strokeLine(x, y - 20, x, y + 20);
-                    annoGC.strokeLine(dragStart[0], y - 20, dragStart[0], y + 20);
-                    annoGC.strokeLine(dragStart[0], y, x, y);
+                    gc.strokeLine(x, y - 20, x, y + 20);
+                    gc.strokeLine(dragStart[0], y - 20, dragStart[0], y + 20);
+                    gc.strokeLine(dragStart[0], y, x, y);
                 } else {
-                    annoGC.strokeLine(x, yPos + borders.getTop(), x, yPos + getHeight() - borders.getBottom());
-                    annoGC.strokeLine(dragStart[0], yPos + borders.getTop(), dragStart[0], yPos + getHeight() - borders.getBottom());
+                    gc.strokeLine(x, yPos + borders.getTop(), x, yPos + getHeight() - borders.getBottom());
+                    gc.strokeLine(dragStart[0], yPos + borders.getTop(), dragStart[0], yPos + getHeight() - borders.getBottom());
                 }
             } else {
-                annoGC.strokeRect(startX, startY, dX, dY);
+                gc.strokeRect(startX, startY, dX, dY);
             }
-            annoGC.setLineDashes(null);
+            gc.setLineDashes(null);
         }
     }
 
@@ -464,10 +464,10 @@ public class PolyChart extends Region implements PeakListener {
     }
 
     public boolean finishBox(MOUSE_ACTION mouseAction, double[] dragStart, double x, double y) {
-        GraphicsContext annoGC = drawingLayers.getSlicesAndDragBoxes().getGraphicsContext2D();
-        double annoWidth = drawingLayers.getSlicesAndDragBoxes().getWidth();
-        double annoHeight = drawingLayers.getSlicesAndDragBoxes().getHeight();
-        annoGC.clearRect(0, 0, annoWidth, annoHeight);
+        GraphicsContext gc = drawingLayers.getGraphicsContextFor(ChartDrawingLayers.Item.DragBoxes);
+        double annoWidth = drawingLayers.getWidth();
+        double annoHeight = drawingLayers.getHeight();
+        gc.clearRect(0, 0, annoWidth, annoHeight);
         double[][] limits;
         if (is1D()) {
             limits = new double[1][2];
@@ -3506,24 +3506,19 @@ public class PolyChart extends Region implements PeakListener {
         double yPos = getLayoutY();
         double width = getWidth();
         double height = getHeight();
-        drawingLayers.getSlicesAndDragBoxes().setWidth(drawingLayers.getWidth());
-        drawingLayers.getSlicesAndDragBoxes().setHeight(drawingLayers.getHeight());
-        GraphicsContext annoGC = drawingLayers.getSlicesAndDragBoxes().getGraphicsContext2D();
-        GraphicsContextInterface gC = new GraphicsContextProxy(annoGC);
+        GraphicsContextInterface gC = drawingLayers.getGraphicsProxyFor(ChartDrawingLayers.Item.Slices);
         gC.clearRect(xPos, yPos, width, height);
         drawSlices(gC);
     }
 
     public void drawSlices(GraphicsContextInterface gC) {
-        if (drawingLayers.getSlicesAndDragBoxes() != null) {
-            if (sliceAttributes.slice1StateProperty().get()) {
-                drawSlice(gC, 0, VERTICAL);
-                drawSlice(gC, 0, HORIZONTAL);
-            }
-            if (sliceAttributes.slice2StateProperty().get()) {
-                drawSlice(gC, 1, VERTICAL);
-                drawSlice(gC, 1, HORIZONTAL);
-            }
+        if (sliceAttributes.slice1StateProperty().get()) {
+            drawSlice(gC, 0, VERTICAL);
+            drawSlice(gC, 0, HORIZONTAL);
+        }
+        if (sliceAttributes.slice2StateProperty().get()) {
+            drawSlice(gC, 1, VERTICAL);
+            drawSlice(gC, 1, HORIZONTAL);
         }
     }
 
@@ -3568,9 +3563,6 @@ public class PolyChart extends Region implements PeakListener {
     }
 
     public void extractSlice(int iOrient) {
-        if (drawingLayers.getSlicesAndDragBoxes() == null) {
-            return;
-        }
         DatasetBase dataset = getDataset();
         if (dataset == null) {
             return;

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChartManager.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChartManager.java
@@ -33,8 +33,8 @@ public class PolyChartManager {
         allCharts.addListener((ListChangeListener<PolyChart>) e -> multipleCharts.set(allCharts.size() > 1));
     }
 
-    public PolyChart create(FXMLController controller, Pane plotContent, Canvas canvas, Canvas peakCanvas, Canvas annoCanvas) {
-        PolyChart chart = new PolyChart(controller, generateNextName(), plotContent, canvas, peakCanvas, annoCanvas);
+    public PolyChart create(FXMLController controller, ChartDrawingLayers drawingLayers) {
+        PolyChart chart = new PolyChart(controller, generateNextName(), drawingLayers);
         registerNewChart(chart);
         return chart;
     }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/controls/GridPaneCanvas.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/controls/GridPaneCanvas.java
@@ -86,7 +86,7 @@ public class GridPaneCanvas extends GridPane {
         super.layoutChildren();
         double width = getWidth();
         double height = getHeight();
-        controller.resizeCanvases(width, height);
+
         GraphicsContext gC = canvas.getGraphicsContext2D();
         gC.clearRect(0, 0, width, height);
         if (controller.getBgColor() != null) {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/spectra/DrawPeaks.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/spectra/DrawPeaks.java
@@ -27,6 +27,7 @@ import javafx.geometry.BoundingBox;
 import javafx.geometry.Bounds;
 import javafx.geometry.VPos;
 import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.Paint;
 import javafx.scene.shape.Path;
@@ -101,12 +102,11 @@ public class DrawPeaks {
     Color selectFill = new Color(1.0f, 1.0f, 0.0f, 0.4f);
     private boolean multipletMode = false;
     List<PeakBox> lastTextBoxes = new TreeList<>();
-    GraphicsContextInterface g2;
+    GraphicsContext g2;
 
-    public DrawPeaks(PolyChart chart, Canvas peakCanvas) {
+    public DrawPeaks(PolyChart chart, GraphicsContext graphics) {
         this.chart = chart;
-        this.g2 = new GraphicsContextProxy(peakCanvas.getGraphicsContext2D());
-        //   setParameters();
+        this.g2 = graphics;
         regions = new HashSet[nRegions];
 
         for (int i = 0; i < regions.length; i++) {

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/spectra/DrawSpectrum.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/spectra/DrawSpectrum.java
@@ -82,7 +82,7 @@ public class DrawSpectrum {
     private final ContoursDrawingService contoursDrawing;
     private final double[][] xy = new double[2][];
     private final PolyChartAxes axes;
-    private GraphicsContextInterface g2;
+    private final GraphicsContextInterface g2;
     private double stackWidth = 0.0;
     private double stackY = 0.0;
     private int nPoints = 0;
@@ -91,12 +91,9 @@ public class DrawSpectrum {
     private long startTime = 0;
     private Rectangle clipRect = null;
 
-    public DrawSpectrum(PolyChartAxes axes, Canvas canvas) {
+    public DrawSpectrum(PolyChartAxes axes, GraphicsContextProxy graphics) {
         this.axes = axes;
-        if (canvas != null) {
-            GraphicsContext g2C = canvas.getGraphicsContext2D();
-            g2 = new GraphicsContextProxy(g2C);
-        }
+        g2 = graphics;
         contoursGeneration = new ContourGenerationService(this);
         contoursDrawing = new ContoursDrawingService(this);
     }


### PR DESCRIPTION
A few direct access to inside canvas remains, but the PR starts to get too big. May be worth an intermediate review.

Goal of this change is to be very clear on what canvas is used to paint what components, show that they are shared, and manage them together as one object. This also removes some cross-references to fxmlcontroller hopefully.