### PR TITLE
NMR-6953: rename remaining accessors

### DIFF
--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartDrawingLayers.java
@@ -18,7 +18,6 @@
 package org.nmrfx.processor.gui;
 
 import javafx.scene.Cursor;
-import javafx.scene.Node;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.input.DragEvent;
@@ -143,16 +142,15 @@ public class ChartDrawingLayers {
         return new GraphicsContextProxy(getGraphicsContextFor(item));
     }
 
-    //XXX try to remove accessor usages from FXMLController
     public GridPaneCanvas getGrid() {
         return grid;
     }
 
-    public Canvas getBase() {
+    public Canvas getBaseCanvas() {
         return base;
     }
 
-    public Pane getTop() {
+    public Pane getTopPane() {
         return top;
     }
 }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -68,7 +68,6 @@ import org.nmrfx.processor.datasets.vendor.jcamp.JCAMPData;
 import org.nmrfx.processor.datasets.vendor.nmrview.NMRViewData;
 import org.nmrfx.processor.datasets.vendor.rs2d.RS2DData;
 import org.nmrfx.processor.gui.controls.GridPaneCanvas;
-import org.nmrfx.processor.gui.spectra.CanvasBindings;
 import org.nmrfx.processor.gui.spectra.DatasetAttributes;
 import org.nmrfx.processor.gui.spectra.PeakDisplayTool;
 import org.nmrfx.processor.gui.spectra.WindowIO;
@@ -677,12 +676,12 @@ public class FXMLController implements Initializable, StageBasedController, Publ
         File selectedFile = fileChooser.showSaveDialog(null);
         if (selectedFile != null) {
             try {
-                chartDrawingLayers.getTop().setVisible(false);
+                chartDrawingLayers.getTopPane().setVisible(false);
                 GUIUtils.snapNode(chartPane, selectedFile);
             } catch (IOException ex) {
                 GUIUtils.warn("Error saving png file", ex.getLocalizedMessage());
             } finally {
-                chartDrawingLayers.getTop().setVisible(true);
+                chartDrawingLayers.getTopPane().setVisible(true);
             }
         }
     }

--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/PolyChart.java
@@ -26,12 +26,10 @@ import javafx.beans.value.ChangeListener;
 import javafx.collections.*;
 import javafx.geometry.*;
 import javafx.scene.Cursor;
-import javafx.scene.Node;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ChoiceDialog;
-import javafx.scene.input.DragEvent;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
@@ -263,7 +261,7 @@ public class PolyChart extends Region implements PeakListener {
 
     private void initChart() {
         crossHairs = new CrossHairs(this);
-        drawingLayers.getTop().getChildren().addAll(crossHairs.getAllGraphicalLines());
+        drawingLayers.getTopPane().getChildren().addAll(crossHairs.getAllGraphicalLines());
 
         highlightRect.setVisible(false);
         highlightRect.setStroke(Color.BLUE);
@@ -273,9 +271,9 @@ public class PolyChart extends Region implements PeakListener {
                 PolyChartManager.getInstance().activeChartProperty().isEqualTo(this)
                         .and(PolyChartManager.getInstance().multipleChartsProperty())
                         .or(chartSelected));
-        drawingLayers.getTop().getChildren().add(highlightRect);
+        drawingLayers.getTopPane().getChildren().add(highlightRect);
         canvasHandles.forEach(handle -> handle.visibleProperty().bind(chartSelected));
-        drawingLayers.getTop().getChildren().addAll(canvasHandles);
+        drawingLayers.getTopPane().getChildren().addAll(canvasHandles);
         axes.init(this);
         drawingLayers.setCursor(CanvasCursor.SELECTOR.getCursor());
         MapChangeListener<String, PeakList> mapChangeListener = change -> purgeInvalidPeakListAttributes();
@@ -296,7 +294,7 @@ public class PolyChart extends Region implements PeakListener {
     }
 
     public Canvas getCanvas() {
-        return drawingLayers.getBase();
+        return drawingLayers.getBaseCanvas();
     }
 
     public PolyChartAxes getAxes() {
@@ -304,13 +302,13 @@ public class PolyChart extends Region implements PeakListener {
     }
 
     public void close() {
-        drawingLayers.getTop().getChildren().removeAll(crossHairs.getAllGraphicalLines());
+        drawingLayers.getTopPane().getChildren().removeAll(crossHairs.getAllGraphicalLines());
 
         highlightRect.visibleProperty().unbind();
-        drawingLayers.getTop().getChildren().remove(highlightRect);
+        drawingLayers.getTopPane().getChildren().remove(highlightRect);
         for (var canvasHandle : canvasHandles) {
-            drawingLayers.getTop().getChildren().remove(canvasHandle);
-            drawingLayers.getTop().visibleProperty().unbind();
+            drawingLayers.getTopPane().getChildren().remove(canvasHandle);
+            drawingLayers.getTopPane().visibleProperty().unbind();
         }
 
         PolyChartManager.getInstance().unregisterChart(this);


### PR DESCRIPTION
I will not be able to do better without investing more time that what I'm willing to invest for now, so 3 layers will remain exposed.
They are used to compute popover coordinates, add items to the top pane, check if charts are on the same pane, etc.