### PR TITLE
NMR-6904: intensityAxis property name didn't match the field name.

### DIFF
--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartProperties.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/ChartProperties.java
@@ -65,7 +65,7 @@ public class ChartProperties implements PublicPropertyContainer {
         rightBorderSize = add(new SimpleIntegerProperty(polyChart, "rightBorderSize", EMPTY_BORDER_DEFAULT_SIZE));
         topBorderSize = add(new SimpleIntegerProperty(polyChart, "topBorderSize", EMPTY_BORDER_DEFAULT_SIZE));
         bottomBorderSize = add(new SimpleIntegerProperty(polyChart, "bottomBorderSize", 0));
-        intensityAxis = add(new SimpleBooleanProperty(polyChart, "onedAxis", false));
+        intensityAxis = add(new SimpleBooleanProperty(polyChart, "intensityAxis", false));
         labelFontSize = add(new SimpleIntegerProperty(polyChart, "labelFontSize", PreferencesController.getLabelFontSize()));
         ticFontSize = add(new SimpleIntegerProperty(polyChart, "ticFontSize", PreferencesController.getTickFontSize()));
         cross1Color = add(new ColorProperty(polyChart, "cross1Color", null));


### PR DESCRIPTION
This lead to an inconsistency when loading existing project files created before the change on public properties management.