### PR TITLE
NMR-6970: move top toolbar to left side

### DIFF
--- a/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
+++ b/nmrfx-analyst-gui/src/main/java/org/nmrfx/processor/gui/FXMLController.java
@@ -149,6 +149,8 @@ public class FXMLController implements Initializable, StageBasedController, Publ
     private BorderPane mainBox;
     @FXML
     private StackPane processorPane;
+    @FXML
+    private HBox leftBar;
     private double previousStageRestoreWidth = 0;
     private double previousStageRestoreProcControllerWidth = 0;
     private boolean previousStageRestoreProcControllerVisible = false;
@@ -1587,7 +1589,6 @@ public class FXMLController implements Initializable, StageBasedController, Publ
 
     private void initToolBar(ToolBar toolBar) {
         ArrayList<Node> buttons = new ArrayList<>();
-
         ButtonBase bButton;
         bButton = GlyphsDude.createIconButton(FontAwesomeIcon.FILE, "Datasets", AnalystApp.ICON_SIZE_STR, AnalystApp.ICON_FONT_SIZE_STR, ContentDisplay.TOP);
         bButton.setOnAction(this::showDatasetsAction);
@@ -1690,6 +1691,8 @@ public class FXMLController implements Initializable, StageBasedController, Publ
             }
         }
         toolBar.getItems().addAll(buttons);
+        // Make all buttons the same width to align the edges
+        toolBar.widthProperty().addListener((observable, oldValue, newValue) -> GUIUtils.nodeAdjustWidths(buttons));
 
         ToolBar btoolBar = new ToolBar();
         ToolBar btoolBar2 = new ToolBar();

--- a/nmrfx-analyst-gui/src/main/resources/fxml/NMRScene.fxml
+++ b/nmrfx-analyst-gui/src/main/resources/fxml/NMRScene.fxml
@@ -10,16 +10,10 @@
     <children>
         <BorderPane fx:id="mainBox" HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS">
             <stylesheets>
-                <URL value="@/styles/Styles.css"/>
+                <URL value="@/styles/Styles.css" />
             </stylesheets>
             <top>
                 <VBox fx:id="topBar" GridPane.hgrow="ALWAYS">
-                    <children>
-                        <ToolBar fx:id="toolBar" prefWidth="200.0" BorderPane.alignment="CENTER">
-                            <items>
-                            </items>
-                        </ToolBar>
-                    </children>
                 </VBox>
             </top>
             <center>
@@ -27,7 +21,7 @@
                     <top>
                     </top>
                     <center>
-                        <StackPane fx:id="chartPane" prefHeight="1000" VBox.vgrow="ALWAYS"/>
+                        <StackPane fx:id="chartPane" prefHeight="1000" VBox.vgrow="ALWAYS" />
                     </center>
                     <right>
                     </right>
@@ -35,20 +29,30 @@
             </center>
             <right>
             </right>
+            <left>
+                <HBox fx:id="leftBar" VBox.vgrow="ALWAYS">
+                <children>
+                    <ToolBar fx:id="toolBar" orientation="VERTICAL" BorderPane.alignment="CENTER">
+                        <items>
+                        </items>
+                    </ToolBar>
+                </children>
+                </HBox>
+            </left>
             <bottom>
                 <VBox fx:id="bottomBox">
                     <children>
                         <VBox fx:id="btoolVBox">
                             <children>
-                                <Pane HBox.hgrow="ALWAYS"/>
+                                <Pane HBox.hgrow="ALWAYS" />
                             </children>
                         </VBox>
                     </children>
                 </VBox>
             </bottom>
         </BorderPane>
-        <Separator orientation="VERTICAL"/>
-        <StackPane fx:id="processorPane" VBox.vgrow="ALWAYS"/>
+        <Separator orientation="VERTICAL" />
+        <StackPane fx:id="processorPane" VBox.vgrow="ALWAYS" />
     </children>
 
 </HBox>

--- a/nmrfx-utils/src/main/java/org/nmrfx/utils/GUIUtils.java
+++ b/nmrfx-utils/src/main/java/org/nmrfx/utils/GUIUtils.java
@@ -234,6 +234,19 @@ public class GUIUtils {
         }
     }
 
+    public static void nodeAdjustWidths(List<Node> nodeList) {
+        // Set width of controls within a toolbar to be the same.
+        Optional<Double> width = nodeList.stream().map(node -> node.prefWidth(Region.USE_COMPUTED_SIZE)).max(Double::compare);
+        if (width.isEmpty()) {
+            return;
+        }
+        for (Node node : nodeList) {
+            if (node instanceof Control control) {
+                control.setPrefWidth(width.get());
+            }
+        }
+    }
+
     public static String getPassword() {
         Dialog<String> dialog = new Dialog<>();
         dialog.setTitle("Password");


### PR DESCRIPTION
Note based off https://github.com/nanalysis/nmrfx/pull/340

Top level toolbar shifted to the left, unsure if spaces from screenshot are needed