### PR TITLE
NMR 7499 Retain unprocessed saveframes

### DIFF
--- a/nmrfx-core/src/main/java/org/nmrfx/chemistry/io/NMRStarWriter.java
+++ b/nmrfx-core/src/main/java/org/nmrfx/chemistry/io/NMRStarWriter.java
@@ -1345,5 +1345,6 @@ public class NMRStarWriter {
             }
         }
         ProjectBase.getActive().writeSaveframes(chan);
+        ProjectBase.getActive().writeIgnoredSaveframes(chan);
     }
 }

--- a/nmrfx-core/src/main/java/org/nmrfx/project/ProjectBase.java
+++ b/nmrfx-core/src/main/java/org/nmrfx/project/ProjectBase.java
@@ -62,6 +62,7 @@ public class ProjectBase {
     protected List<DatasetBase> datasets = new ArrayList<>();
     protected Map<String, PeakList> peakLists = new HashMap<>();
     protected List<SaveframeWriter> extraSaveframes = new ArrayList<>();
+    private static List<Saveframe> ignoredSaveframes = new ArrayList<>();
 
     protected ProjectBase(String name) {
         this.name = name;
@@ -115,6 +116,10 @@ public class ProjectBase {
             fileNum = Optional.of(Integer.parseInt(matcher2.group(1)));
         }
         return fileNum;
+    }
+
+    public static void addIgnoredSaveframe(Saveframe saveframe) {
+        ignoredSaveframes.add(saveframe);
     }
 
     public final void setActive() {
@@ -192,6 +197,16 @@ public class ProjectBase {
         for (SaveframeWriter saveframeWriter : extraSaveframes) {
             saveframeWriter.write(chan);
         }
+    }
+
+    public void writeIgnoredSaveframes(Writer chan) throws IOException {
+        for (Saveframe saveframe : ignoredSaveframes) {
+            chan.write(saveframe.getRawText());
+        }
+    }
+
+    public static boolean recognizedExtraSaveFrame(Saveframe saveframe) {
+        return saveframeProcessors.containsKey(saveframe.getCategoryName());
     }
 
     public static void processExtraSaveFrames(STAR3 star3) throws ParseException {

--- a/nmrfx-core/src/main/java/org/nmrfx/star/STAR3Base.java
+++ b/nmrfx-core/src/main/java/org/nmrfx/star/STAR3Base.java
@@ -62,6 +62,10 @@ public class STAR3Base {
         return lineReader.getLineNumber();
     }
 
+    public LineNumberReader getLineReader() {
+        return lineReader;
+    }
+
     public void writeToken(String token) {
         out.print(token);
     }


### PR DESCRIPTION
Current bahvior:
 -saveframes which are not recognized are currently dropped when saving

Preferred behavior:
 - saveframes which are not recognized are written unaltered on saving

This pull request:
 - Adds a new field in Saveframe which stores the raw text of that saveframe
 - Adds a field in ProjectBase which contains a list of saveframes which do not belong to a recognized category
 - Writes out raw text of unprocessed saveframes on project write

Notes:
 - The raw text is populated during a second pass of the star file (using mark and reset methods of LineNumberReader). If the readAheadLimit parameter for the mark method is too small, the saveframe will not be written. To avoid this, we set the read ahead limit to be the same as the total file size

 - At present this only applies to star files. Ideally the other writers would also retain unrecognized saveframes