### PR TITLE
Don't clean resonances until after all saveframes are read

### DIFF
--- a/nmrfx-analyst-gui/pom.xml
+++ b/nmrfx-analyst-gui/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.nmrfx</groupId>
         <artifactId>nmrfx</artifactId>
-        <version>11.3.5-SNAPSHOT</version>
+        <version>11.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -22,7 +22,7 @@
             <dependency>
                 <groupId>org.nmrfx</groupId>
                 <artifactId>nmrfx-bom</artifactId>
-                <version>11.3.5-SNAPSHOT</version>
+                <version>11.4.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -33,12 +33,12 @@
         <dependency>
             <groupId>org.nmrfx</groupId>
             <artifactId>nmrfx-analyst</artifactId>
-            <version>11.3.5-SNAPSHOT</version>
+            <version>11.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.nmrfx</groupId>
             <artifactId>nmrfx-plugin-api</artifactId>
-            <version>11.3.5-SNAPSHOT</version>
+            <version>11.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.fxmisc.richtext</groupId>

--- a/nmrfx-analyst/pom.xml
+++ b/nmrfx-analyst/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.nmrfx</groupId>
         <artifactId>nmrfx</artifactId>
-        <version>11.3.5-SNAPSHOT</version>
+        <version>11.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -18,7 +18,7 @@
             <dependency>
                 <groupId>org.nmrfx</groupId>
                 <artifactId>nmrfx-bom</artifactId>
-                <version>11.3.5-SNAPSHOT</version>
+                <version>11.4.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -29,17 +29,17 @@
         <dependency>
             <groupId>org.nmrfx</groupId>
             <artifactId>nmrfx-core</artifactId>
-            <version>11.3.5-SNAPSHOT</version>
+            <version>11.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.nmrfx</groupId>
             <artifactId>nmrfx-utils</artifactId>
-            <version>11.3.5-SNAPSHOT</version>
+            <version>11.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.nmrfx</groupId>
             <artifactId>nmrfx-structure</artifactId>
-            <version>11.3.5-SNAPSHOT</version>
+            <version>11.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.nanalysis</groupId>

--- a/nmrfx-bom/pom.xml
+++ b/nmrfx-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.nmrfx</groupId>
         <artifactId>nmrfx</artifactId>
-        <version>11.3.5-SNAPSHOT</version>
+        <version>11.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/nmrfx-core/pom.xml
+++ b/nmrfx-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.nmrfx</groupId>
         <artifactId>nmrfx</artifactId>
-        <version>11.3.5-SNAPSHOT</version>
+        <version>11.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -18,7 +18,7 @@
             <dependency>
                 <groupId>org.nmrfx</groupId>
                 <artifactId>nmrfx-bom</artifactId>
-                <version>11.3.5-SNAPSHOT</version>
+                <version>11.4.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/nmrfx-core/src/main/java/org/nmrfx/chemistry/io/NMRStarReader.java
+++ b/nmrfx-core/src/main/java/org/nmrfx/chemistry/io/NMRStarReader.java
@@ -1720,10 +1720,12 @@ public class NMRStarReader {
             buildRunAbout();
             log.debug("process paths");
             buildPeakPaths();
+
+            ProjectBase.processExtraSaveFrames(star3);
+
             log.debug("clean resonances");
             resFactory.clean();
 
-            ProjectBase.processExtraSaveFrames(star3);
             log.debug("process done");
         } else if ("shifts".startsWith(argv[0])) {
             int fromSet = Integer.parseInt(argv[1]);

--- a/nmrfx-jmx-connector/pom.xml
+++ b/nmrfx-jmx-connector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.nmrfx</groupId>
         <artifactId>nmrfx</artifactId>
-        <version>11.3.5-SNAPSHOT</version>
+        <version>11.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -17,12 +17,12 @@
         <dependency>
             <groupId>org.nmrfx</groupId>
             <artifactId>nmrfx-analyst-gui</artifactId>
-            <version>11.3.5-SNAPSHOT</version>
+            <version>11.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.nmrfx</groupId>
             <artifactId>nmrfx-plugin-api</artifactId>
-            <version>11.3.5-SNAPSHOT</version>
+            <version>11.4.0</version>
         </dependency>
     </dependencies>
 

--- a/nmrfx-plugin-api/pom.xml
+++ b/nmrfx-plugin-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.nmrfx</groupId>
         <artifactId>nmrfx</artifactId>
-        <version>11.3.5-SNAPSHOT</version>
+        <version>11.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -19,7 +19,7 @@
             <dependency>
                 <groupId>org.nmrfx</groupId>
                 <artifactId>nmrfx-bom</artifactId>
-                <version>11.3.5-SNAPSHOT</version>
+                <version>11.4.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/nmrfx-structure/pom.xml
+++ b/nmrfx-structure/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.nmrfx</groupId>
         <artifactId>nmrfx</artifactId>
-        <version>11.3.5-SNAPSHOT</version>
+        <version>11.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -19,7 +19,7 @@
             <dependency>
                 <groupId>org.nmrfx</groupId>
                 <artifactId>nmrfx-bom</artifactId>
-                <version>11.3.5-SNAPSHOT</version>
+                <version>11.4.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.nmrfx</groupId>
             <artifactId>nmrfx-core</artifactId>
-            <version>11.3.5-SNAPSHOT</version>
+            <version>11.4.0</version>
         </dependency>
         <dependency>
             <groupId>javax.vecmath</groupId>

--- a/nmrfx-utils/pom.xml
+++ b/nmrfx-utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.nmrfx</groupId>
         <artifactId>nmrfx</artifactId>
-        <version>11.3.5-SNAPSHOT</version>
+        <version>11.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -18,7 +18,7 @@
             <dependency>
                 <groupId>org.nmrfx</groupId>
                 <artifactId>nmrfx-bom</artifactId>
-                <version>11.3.5-SNAPSHOT</version>
+                <version>11.4.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.nmrfx</groupId>
     <artifactId>nmrfx</artifactId>
-    <version>11.3.5-SNAPSHOT</version>
+    <version>11.4.0</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
saveframes read via ProjectBase.processExtraSaveFrames(star3) may include resonance numbers. These are renumbered and therefore not accessible following resFactory.clean()